### PR TITLE
Enable pierone authentication for the etcd-cluster.

### DIFF
--- a/docs/user-guide/deploy_etcd.md
+++ b/docs/user-guide/deploy_etcd.md
@@ -7,10 +7,12 @@ The following prerequisites need to be met.
 * A [Senza Definition](http://stups.readthedocs.org/en/latest/components/senza.html#senza-definition)
 * A template can be found here: [etcd-appliance.yaml](https://github.com/zalando/spilo/blob/master/etcd-cluster-appliance/etcd-cluster.yaml)
 * The Security Group defined in the Senza Definition needs to be created
+* The appliction\_id `etcd-cluster` needs to be registered in yourturn
+* The S3 mint bucket needs to be added to the Access Control
 
 To deploy the etcd-appliance, use the following:
 
-	senza create DEFINITION.yaml VERSION HOSTED_ZONE DOCKER_IMAGE
+	senza create DEFINITION.yaml VERSION HOSTED_ZONE DOCKER_IMAGE MINT_BUCKET
 
 This will create and execute a cloud formation template for you.
 
@@ -19,10 +21,10 @@ Example:
 Argument   		   | Value
 -------------------|-------
 Definition         | etcd-appliance.yaml
-Hosted zone 	   | repository.example.com
-Version 		   | 1
+Hosted zone 	   | team.example.com
+Version 		   | release
 Docker repository  | docker.registry.example.com
 Docker image       | repository/etcd-appliance
 Image tag          | 0.2-SNAPSHOT
 
-	senza create etcd-cluster.yaml 1 repository.example.com docker.registry.example.com/repository/etcd-appliance:0.2-SNAPSHOT
+	senza create etcd-cluster.yaml release team.example.com docker.registry.example.com/repository/etcd-appliance:0.2-SNAPSHOT bytes-other-12345690-us-west-1

--- a/docs/user-guide/deploy_spilo.md
+++ b/docs/user-guide/deploy_spilo.md
@@ -4,6 +4,8 @@ Prerequisites
 * Have an etcd-cluster available
 * Have some global idea about the usage characteristics of the appliance
 * Have unique name for the cluster
+* The appliction\_id `spilo` (you can change this though) needs to be registered in yourturn
+* The S3 mint bucket needs to be added to the Access Control
 
 You can use senza init to create a senza definition for the spilo appliance,
 the `ETCD_DISCOVERY_URL` should point to `HOSTED_ZONE` from the etcd-appliance that you want to use.

--- a/etcd-cluster-appliance/etcd-cluster.yaml
+++ b/etcd-cluster-appliance/etcd-cluster.yaml
@@ -15,6 +15,7 @@ SenzaComponents:
       source: '{{Arguments.DockerImage}}'
       environment:
         HOSTED_ZONE: '{{Arguments.HostedZone}}'
+      mint_bucket: '{{Arguments.MintBucket}}'
     Type: Senza::TaupageAutoScalingGroup
     AutoScaling:
         Minimum: 3
@@ -26,6 +27,8 @@ SenzaInfo:
       Description: AWS Hosted Zone to work with
   - DockerImage:
       Description: Docker image of etcd-cluster.
+  - MintBucket:
+      Description: The mint S3 bucket for OAuth 2.0 credentials
   StackName: etcd-cluster
 Resources:
   EtcdRole:
@@ -50,6 +53,9 @@ Resources:
           - Effect: Allow
             Action: autoscaling:Describe*
             Resource: "*"
+          - Effect: Allow
+            Action: "s3:GetObject"
+            Resource: ["arn:aws:s3:::{{Arguments.MintBucket}}/*"]
       - PolicyName: AmazonRoute53Access
         PolicyDocument:
           Version: "2012-10-17"


### PR DESCRIPTION
Extend the DEFINITION.yaml file to include the mint bucket, update the
documentation to add the dependency on mint and berry.
Expand the privileges of the IAM role to be able to get the objects out of the
specified mint bucket.

Tested and found working.