### PR TITLE
Allow connections to the cluster from the outside world.

### DIFF
--- a/postgres-appliance/postgres_ha.sh
+++ b/postgres-appliance/postgres_ha.sh
@@ -28,6 +28,8 @@ postgresql:
   listen: 0.0.0.0:${pg_port}
   connect_address: ${aws_private_ip}:${pg_port}
   data_dir: $PGDATA
+  pg_hba:
+  - hostssl all all 0.0.0.0/0 md5
   replication:
     username: standby
     password: standby

--- a/postgres-appliance/postgres_ha.sh
+++ b/postgres-appliance/postgres_ha.sh
@@ -30,6 +30,7 @@ postgresql:
   data_dir: $PGDATA
   pg_hba:
   - hostssl all all 0.0.0.0/0 md5
+  - host    all all 0.0.0.0/0 md5
   replication:
     username: standby
     password: standby


### PR DESCRIPTION
Due to a change in Governor, pg_hba entries need to be specified to enable
connections to the cluster. This fixes https://github.com/zalando/spilo/issues/6.