### PR TITLE
Bugfix for restarting docker container.

### DIFF
--- a/postgres-appliance/postgres_ha.sh
+++ b/postgres-appliance/postgres_ha.sh
@@ -13,7 +13,7 @@ function write_postgres_yaml
   local pg_port=5432
   local api_port=8008
 
-  cat >> postgres.yml <<__EOF__
+  cat > postgres.yml <<__EOF__
 ttl: &ttl 30
 loop_wait: &loop_wait 10
 scope: &scope $SCOPE
@@ -105,8 +105,11 @@ function write_archive_command_environment
 
 write_postgres_yaml
 
-# get patroni code
-git clone https://github.com/zalando/patroni.git
+if [[ ! -d "patroni" ]]
+then
+    # get patroni code
+    git clone https://github.com/zalando/patroni.git
+fi
 
 write_archive_command_environment
 


### PR DESCRIPTION
When a previously stopped docker container is started again the following errors show up:
    yaml.composer.ComposerError: found duplicate anchor 'ttl'; first occurence
This is fixed by not appending to postgres.yml for the first entry, but by writing to it

The other issue is:
    fatal: destination path 'patroni' already exists and is not an empty directory
This is because git clone cannot clone into an already existing patroni directory
This is fixed by only executing git clone if the directory does not yet exist.