### PR TITLE
Refer to a tagged Patroni version to use within Spilo

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -58,8 +58,14 @@ ENV PATH $PATH:/usr/lib/postgresql-${PGVERSION}/bin
 # Copy the snakeoil certificates for usage as dummy certificates
 RUN cp /etc/ssl/private/ssl-cert-snakeoil.key $PGHOME/dummy.key && cp /etc/ssl/certs/ssl-cert-snakeoil.pem $PGHOME/dummy.crt
 
+# Install Patroni
+ENV PATRONIVERSION 0.1
+RUN git clone https://github.com/zalando/patroni.git
+WORKDIR /patroni
+RUN git checkout tags/v${PATRONIVERSION}
+
 ADD postgres_ha.sh /
-RUN chown postgres:postgres $PGHOME -R
+RUN chown postgres:postgres $PGHOME /patroni -R
 RUN chown postgres:postgres /postgres_ha.sh
 RUN chmod 700 /postgres_ha.sh
 

--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -60,12 +60,13 @@ RUN cp /etc/ssl/private/ssl-cert-snakeoil.key $PGHOME/dummy.key && cp /etc/ssl/c
 
 # Install Patroni
 ENV PATRONIVERSION 0.1
+WORKDIR $PGHOME
 RUN git clone https://github.com/zalando/patroni.git
-WORKDIR /patroni
+WORKDIR $PGHOME/patroni
 RUN git checkout tags/v${PATRONIVERSION}
 
 ADD postgres_ha.sh /
-RUN chown postgres:postgres $PGHOME /patroni -R
+RUN chown postgres:postgres $PGHOME -R
 RUN chown postgres:postgres /postgres_ha.sh
 RUN chmod 700 /postgres_ha.sh
 

--- a/postgres-appliance/postgres_ha.sh
+++ b/postgres-appliance/postgres_ha.sh
@@ -111,13 +111,6 @@ function write_archive_command_environment
 }
 
 write_postgres_yaml
-
-if [[ ! -d "patroni" ]]
-then
-    # get patroni code
-    git clone https://github.com/zalando/patroni.git
-fi
-
 write_archive_command_environment
 
 # run wal-e s3 backup periodically


### PR DESCRIPTION
To make sure Spilo is delivering a working container every time, we need to make all the software it uses immutable.
For this, upstream Patroni has already been tagged.
The cloning and checking out of the right tag is now done in the Dockerfile, which makes it immutable.