### PR TITLE
Explicitly set keepalives.

### DIFF
--- a/postgres-appliance/postgres_ha.sh
+++ b/postgres-appliance/postgres_ha.sh
@@ -96,6 +96,8 @@ postgresql:
     archive_timeout: 1800s
     max_replication_slots: 5
     hot_standby: "on"
+    tcp_keepalives_idle: 900
+    tcp_keepalives_interval: 100
     ssl: "on"
     ssl_cert_file: "$SSL_CERTIFICATE"
     ssl_key_file: "$SSL_PRIVATE_KEY"


### PR DESCRIPTION
To ensure we keep the connection alive to the ELB, we send a keepalive after 15 minutes.
The default of the OS is normally 2 hours, the maximum for the ELB is 3600 seconds.

This addresses issue #25 partly, by ensuring the connection between the ELB and PostgreSQL is
kept alive.

This also requires the ELB connection timeout to increase.