### PR TITLE
Drop snakeoil certificate.

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -56,9 +56,6 @@ ENV ETCDVERSION 2.2.1
 RUN curl -L https://github.com/coreos/etcd/releases/download/v${ETCDVERSION}/etcd-v${ETCDVERSION}-linux-amd64.tar.gz \
     | tar xz -C /bin --strip=1 --wildcards --no-anchored etcd etcdctl
 
-# Copy the snakeoil certificates for usage as dummy certificates
-RUN cp /etc/ssl/private/ssl-cert-snakeoil.key $PGHOME/dummy.key && cp /etc/ssl/certs/ssl-cert-snakeoil.pem $PGHOME/dummy.crt
-
 # Install Patroni
 ENV PATRONIVERSION 0.75
 WORKDIR $PGHOME

--- a/postgres-appliance/postgres_ha.sh
+++ b/postgres-appliance/postgres_ha.sh
@@ -19,16 +19,16 @@ function write_patronictl_yaml
 
 function generate_certificates
 {
-    if [ -z ${SSL_PRIVATE_KEY} ]
+    if [ -n "${SSL_PRIVATE_KEY}" ]
     then
-        SSL_CERTIFICATE_FILE="$PGHOME/dummy.crt"
-        SSL_PRIVATE_KEY_FILE="$PGHOME/dummy.key"
-        openssl req -nodes -new -x509 -keyout "${SSL_PRIVATE_KEY_FILE}" -out "${SSL_CERTIFICATE_FILE}" -subj "/CN=spilo.dummy.org"
-    else
         SSL_CERTIFICATE_FILE="$PGHOME/server.crt"
         SSL_PRIVATE_KEY_FILE="$PGHOME/server.key"
         echo "${SSL_PRIVATE_KEY}" > "${SSL_PRIVATE_KEY_FILE}"
         echo "${SSL_CERTIFICATE}" > "${SSL_CERTIFICATE_FILE}"
+    else
+        SSL_CERTIFICATE_FILE="$PGHOME/dummy.crt"
+        SSL_PRIVATE_KEY_FILE="$PGHOME/dummy.key"
+        openssl req -nodes -new -x509 -keyout "${SSL_PRIVATE_KEY_FILE}" -out "${SSL_CERTIFICATE_FILE}" -subj "/CN=spilo.dummy.org"
     fi
     chmod 0600 "${SSL_PRIVATE_KEY_FILE}"
 }
@@ -135,8 +135,8 @@ postgresql:
     tcp_keepalives_idle: 900
     tcp_keepalives_interval: 100
     ssl: "on"
-    ssl_cert_file: "$SSL_CERTIFICATE_FILE"
-    ssl_key_file: "$SSL_PRIVATE_KEY_FILE"
+    ssl_cert_file: "${SSL_CERTIFICATE_FILE}"
+    ssl_key_file: "${SSL_PRIVATE_KEY_FILE}"
     wal_log_hints: 'on'
   recovery_conf:
     restore_command: "envdir ${WALE_ENV_DIR} wal-e --aws-instance-profile wal-fetch \"%f\" \"%p\" -p 1"
@@ -152,10 +152,10 @@ function write_archive_command_environment
   echo "https+path://s3-$region.amazonaws.com:443" > ${WALE_ENV_DIR}/WALE_S3_ENDPOINT
 }
 
+generate_certificates
 write_patronictl_yaml
 write_postgres_yaml
 write_archive_command_environment
-generate_certificates
 
 # run wal-e s3 backup periodically
 (

--- a/postgres-appliance/postgres_ha.sh
+++ b/postgres-appliance/postgres_ha.sh
@@ -19,6 +19,12 @@ function write_patronictl_yaml
     fi
 }
 
+function generate_dummy_certificates
+{
+    openssl req -nodes -new -x509 -keyout "${SSL_PRIVATE_KEY}" -out "${SSL_CERTIFICATE}" -subj "/CN=spilo.dummy.org"
+    chmod 0600 "${SSL_PRIVATE_KEY}"
+}
+
 function write_postgres_yaml
 {
   local aws_private_ip=$(curl -s http://instance-data/latest/meta-data/local-ipv4)
@@ -141,6 +147,7 @@ function write_archive_command_environment
 write_patronictl_yaml
 write_postgres_yaml
 write_archive_command_environment
+generate_dummy_certificates
 
 # run wal-e s3 backup periodically
 (
@@ -204,6 +211,3 @@ write_archive_command_environment
 
 [[ "$DEBUG" == 1 ]] && exec /bin/bash
 exec patroni "$PGHOME/postgres.yml"
-
-
-


### PR DESCRIPTION
To ensure some level of reliable encryption, every instance now creates their own self-signed certificate during
boot. The previous reliance on the snakeoil certificate in the Docker image, allowed anyone (the image being public)
to decrypt ssl traffic from Spilo.
With this change we fix the issue of the certificate being known to others.