### PR TITLE
Change the default lag to almost 16MB.

### DIFF
--- a/postgres-appliance/postgres_ha.sh
+++ b/postgres-appliance/postgres_ha.sh
@@ -96,6 +96,7 @@ postgresql:
   pg_hba:
   - hostssl all all 0.0.0.0/0 md5
   - host    all all 0.0.0.0/0 md5
+  maximum_lag_on_failover: 16777215 # (1 byte less than 16MB)
   replication:
     username: standby
     password: "${PGPASSWORD_STANDBY}"


### PR DESCRIPTION
This allows replica's that cannot connect to the master (password issue, master died on heavy load)
to become eligible to run as master. The default value is chosen in such a way that the difference
is never more than 1 archived wal file, as these should be available from s3.