### PR TITLE
Add scm-source to Dockerfile when building.

### DIFF
--- a/postgres-appliance/.gitignore
+++ b/postgres-appliance/.gitignore
@@ -1,0 +1,1 @@
+scm-source.json

--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -75,6 +75,7 @@ ENV WALE_BACKUP_THRESHOLD_MEGABYTES 1024
 ENV WALE_BACKUP_THRESHOLD_PERCENTAGE 30
 ENV WALE_ENV_DIR $PGHOME/etc/wal-e.d/env
 ENV LC_ALL en_US.utf-8
+ADD scm-source.json /scm-source.json
 WORKDIR $PGHOME
 USER postgres
 ENTRYPOINT ["/bin/bash", "/postgres_ha.sh"]

--- a/postgres-appliance/build.sh
+++ b/postgres-appliance/build.sh
@@ -20,7 +20,7 @@ cat > scm-source.json <<__EOT__
     "url": "$URL",
     "revision": "$REV",
     "author": "$GITAUTHOR",
-    "status": "'$STATUS'"
+    "status": "$STATUS"
 }
 __EOT__
 

--- a/postgres-appliance/build.sh
+++ b/postgres-appliance/build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+DOCKERCMD="docker build"
+
+function usage()
+{
+    cat <<__EOF__
+Usage: $0 [DOCKER ARGUMENTS]
+
+__EOF__
+}
+
+REV=$(git rev-parse HEAD)
+URL=$(git config --get remote.origin.url)
+STATUS=$(git status --porcelain)
+GITAUTHOR=$(git show -s --format="%aN <%aE>" "$REV")
+
+cat > scm-source.json <<__EOT__
+{
+    "url": "$URL",
+    "revision": "$REV",
+    "author": "$GITAUTHOR",
+    "status": "'$STATUS'"
+}
+__EOT__
+
+${DOCKERCMD} $@
+EXITCODE=$?
+
+if [[ $EXITCODE != 0 ]]
+then
+    echo "Docker build failed, exitcode is ${EXITCODE}"
+    exit ${EXITCODE}
+fi


### PR DESCRIPTION
To be compliant with Stups we need to ensure we add an up-to-date
scm-source.json file to the root of the Docker container.