### PR TITLE
Introduce patroni_wait

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -76,7 +76,7 @@ RUN usermod -d $PGHOME -m postgres
 # Allow cron to be started by postgres
 RUN echo "postgres ALL=(ALL:ALL) NOPASSWD: /usr/sbin/cron" > /etc/sudoers
 
-ADD scm-source.json postgres_ha.py postgres_backup.sh /
+ADD scm-source.json postgres_ha.py postgres_backup.sh patroni_wait.sh /
 RUN chmod 700 /postgres_*
 RUN chown -R postgres:postgres /postgres_* $PGHOME
 

--- a/postgres-appliance/patroni_wait.sh
+++ b/postgres-appliance/patroni_wait.sh
@@ -3,31 +3,69 @@
 if [ -z $1 ]
 then
     cat <<__EOT__
-Usage: $0 ROLE [INTERVAL] [TIMEOUT]
+Usage: $0 [OPTIONS] [-- COMMAND [ARG1] [ARG2]]
+
+Options:
+
+    -i, --interval  Specify the polling INTERVAL (default: $INTERVAL)
+
+    -r, --role      Which ROLE to wait upon (default: $ROLE)
+
+    -t, --timeout   Fail after TIMEOUT seconds (default: no timeout)
 
 Waits for ROLE (master or replica). It will check every INTERVAL seconds ($INTERVAL).
 If TIMEOUT is specified, it will stop trying after TIMEOUT seconds.
 
-returns 0 when ROLE is available
-returns 2 if the request timed out
+Executes COMMAND after ROLE has become available. (Default: exit 0)
+returns 2 if the request timed out.
+
+Examples:
+
+    $0 -r replica -- echo "Replica is available"
+    $0 -t 1800 -- pg_basebackup -h localhost -D /tmp/backup --xlog-method=stream
 __EOT__
     exit 1
 fi
 
-ROLE=$1
-INTERVAL=$2
-TIMEOUT=$3
+ROLE=master
+INTERVAL=60
+TIMEOUT=""
 
-[ -z "$INTERVAL" ] && INTERVAL=60
-[ -z "$APIPORT" ]  && APIPORT=8008
+while [ $# -gt 0 ]
+do
+    case $1 in
+    -r|--role)
+        ROLE=$2
+        shift
+        ;;
+    -i|--interval)
+        INTERVAL=$2
+        shift
+        ;;
+    -t|--timeout)
+        TIMEOUT=$2
+        shift
+        ;;
+    --)
+        shift
+        break
+        ;;
+    *)
+        echo "Unknown option: $1"
+        exit 1
+        ;;
+    esac
+    shift
+done
 
 CUTOFF=$(date --date="$TIMEOUT seconds" +%s)
 
 while :
 do
-    [ $(curl -o /dev/null --silent --write-out '%{http_code}\n' "localhost:8008/$ROLE") -eq 200 ] && exit 0
+    [ $(curl -o /dev/null --silent --write-out '%{http_code}\n' "localhost:8008/$ROLE") -eq 200 ] && break
     [ ! -z "$TIMEOUT" ] && [ $CUTOFF -le $(date +%s) ] && exit 2
     sleep $INTERVAL
 done
 
-exit 1
+## Execute the command that was specified
+[ $# -gt 0 ] && exec "$@"

--- a/postgres-appliance/patroni_wait.sh
+++ b/postgres-appliance/patroni_wait.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
+ROLE=master
+INTERVAL=60
+TIMEOUT=""
+
 if [ -z $1 ]
 then
     cat <<__EOT__
-Usage: $0 [OPTIONS] [-- COMMAND [ARG1] [ARG2]]
+Usage: $(basename 0) [OPTIONS] [-- COMMAND [ARG1] [ARG2]]
 
 Options:
 
@@ -21,15 +25,12 @@ returns 2 if the request timed out.
 
 Examples:
 
-    $0 -r replica -- echo "Replica is available"
-    $0 -t 1800 -- pg_basebackup -h localhost -D /tmp/backup --xlog-method=stream
+    $(basename $0) -r replica -- echo "Replica is available"
+    $(basename $0) -t 1800 -- pg_basebackup -h localhost -D /tmp/backup --xlog-method=stream
 __EOT__
     exit 1
 fi
 
-ROLE=master
-INTERVAL=60
-TIMEOUT=""
 
 while [ $# -gt 0 ]
 do

--- a/postgres-appliance/patroni_wait.sh
+++ b/postgres-appliance/patroni_wait.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+if [ -z $1 ]
+then
+    cat <<__EOT__
+Usage: $0 ROLE [INTERVAL] [TIMEOUT]
+
+Waits for ROLE (master or replica). It will check every INTERVAL seconds ($INTERVAL).
+If TIMEOUT is specified, it will stop trying after TIMEOUT seconds.
+
+returns 0 when ROLE is available
+returns 2 if the request timed out
+__EOT__
+    exit 1
+fi
+
+ROLE=$1
+INTERVAL=$2
+TIMEOUT=$3
+
+[ -z "$INTERVAL" ] && INTERVAL=60
+[ -z "$APIPORT" ]  && APIPORT=8008
+
+CUTOFF=$(date --date="$TIMEOUT seconds" +%s)
+
+while :
+do
+    [ $(curl -o /dev/null --silent --write-out '%{http_code}\n' "localhost:8008/$ROLE") -eq 200 ] && exit 0
+    [ ! -z "$TIMEOUT" ] && [ $CUTOFF -le $(date +%s) ] && exit 2
+    sleep $INTERVAL
+done
+
+exit 1

--- a/postgres-appliance/postgres_backup.sh
+++ b/postgres-appliance/postgres_backup.sh
@@ -5,32 +5,15 @@ function log
     echo "$(date "+%Y-%m-%d %H:%M:%S.%3N") - $0 - $@"
 }
 
-function wait_for_cluster
-{
-    local SECONDS=${1}
-    [[ -z $1 ]] && SECONDS=0
-    local FINAL_EPOCH=$(date --date "$SECONDS seconds" +%s)
-
-    while true
-    do
-        pg_isready --quiet && return 0
-        log "Cluster is not yet available, waiting"
-        [[ $(date +%s) -lt ${FINAL_EPOCH} ]] || break
-        sleep 5
-    done
-
-    log "ERROR: cluster was not available after $SECONDS seconds"
-    return 1
-}
-
 [[ -z $2 ]] && echo "Usage: $0 WALE_ENV_DIR PGDATA" && exit 1
 
 log "I was called as: $0 $@"
 
+TIMEOUT=0
 if [[ ! -z ${INITIAL_BACKUP+1} ]]
 then
     log "Initial backup, we wait for the cluster to become available"
-    wait_for_cluster 3600
+    TIMEOUT=3600
 fi
 
 WALE_ENV_DIR=$1
@@ -39,14 +22,12 @@ shift
 PGDATA=$1
 shift
 
-
-
-IN_RECOVERY=$(psql -tXqAc "select pg_is_in_recovery()")
-[[ $IN_RECOVERY != "f" ]] && log "Cluster is in recovery, not running backup" && exit 0
+/patroni_wait.sh master 60 $TIMEOUT
+[ $? -ne 0 ] && log "PostgreSQL master is unavailable after $TIMEOUT seconds" && exit 0
 
 # leave only 2 base backups before creating a new one
 envdir "${WALE_ENV_DIR}" wal-e --aws-instance-profile delete --confirm retain 2
 
 # push a new base backup
 log "producing a new backup"
-envdir "${WALE_ENV_DIR}" wal-e --aws-instance-profile backup-push "${PGDATA}"
+exec envdir "${WALE_ENV_DIR}" wal-e --aws-instance-profile backup-push "${PGDATA}"

--- a/postgres-appliance/postgres_ha.py
+++ b/postgres-appliance/postgres_ha.py
@@ -298,9 +298,9 @@ def main():
     write_crontab(placeholders, os.environ.get('PATH'))
     subprocess.call(['/usr/bin/sudo', '/usr/sbin/cron'])
 
-    # # We run 1 backup, with INITIAL_BACKUP set
-    subprocess.Popen(['/bin/bash', '/postgres_backup.sh', placeholders['WALE_ENV_DIR'], placeholders['PGDATA']],
-                     env={'PATH': os.environ['PATH'], 'INITIAL_BACKUP': '1'})
+    # # We run 1 backup, we wait up to 1 hour for the master to be available
+    subprocess.Popen(['/bin/bash', '/patroni_wait.sh', '--timeout', '3600', '--', '/postgres_backup.sh',
+                      placeholders['WALE_ENV_DIR'], placeholders['PGDATA']], env={'PATH': os.environ['PATH']})
 
     env = {'PATH': os.environ['PATH']}
     cmd = ['patroni', 'patroni']


### PR DESCRIPTION
Create a script that can be reused to wait PostgreSQL to get a certain role.
This can be used by tools that require PostgreSQL to run a certain role
(pgq ticker, backup).