### PR TITLE
Add pgq into Spilo

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -27,6 +27,7 @@ RUN export DISTRIB_CODENAME=$(sed -n 's/DISTRIB_CODENAME=//p' /etc/lsb-release) 
 ENV PGVERSION=9.5 PGOLDVERSIONS="9.4"
 RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update \
+    && apt-get install -y skytools3-ticker \
     && for version in ${PGOLDVERSIONS} ${PGVERSION}; do \
             # Install PostgreSQL binaries, contrib, pgq, plproxy, pgq and plpython
             apt-get install -y postgresql-${version} postgresql-${version}-dbg postgresql-client-${version} \
@@ -77,6 +78,7 @@ RUN usermod -d $PGHOME -m postgres
 
 ADD scm-source.json configure_spilo.py launch.sh postgres_backup.sh patroni_wait.sh /
 ADD supervisor.d /etc/supervisor/conf.d/
+ADD pgq_ticker.ini $PGHOME
 ADD motd /etc/
 RUN echo "source /etc/motd" >> /root/.bashrc
 RUN chmod 700 /postgres_*

--- a/postgres-appliance/pgq_ticker.ini
+++ b/postgres-appliance/pgq_ticker.ini
@@ -1,0 +1,9 @@
+[pgqd]
+job_name = ticker
+initial_database = postgres
+
+# how often to run maintenance [seconds]
+maint_delay = 20
+
+# how often to check for activity [seconds]
+loop_delay = 0.1

--- a/postgres-appliance/pgq_ticker.ini
+++ b/postgres-appliance/pgq_ticker.ini
@@ -3,7 +3,7 @@ job_name = ticker
 initial_database = postgres
 
 # how often to run maintenance [seconds]
-maint_delay = 20
+maint_delay = 600
 
 # how often to check for activity [seconds]
-loop_delay = 0.1
+loop_delay = 60

--- a/postgres-appliance/supervisor.d/patroni.conf
+++ b/postgres-appliance/supervisor.d/patroni.conf
@@ -1,5 +1,5 @@
 [program:patroni]
-priority=999
+priority=500
 autorestort=unexpected
 exitcodes=0,2
 user=postgres

--- a/postgres-appliance/supervisor.d/pgq.conf
+++ b/postgres-appliance/supervisor.d/pgq.conf
@@ -1,0 +1,10 @@
+[program:pgq]
+priority=999
+directory=/
+user=postgres
+environment=PGAPPNAME="pgq ticker"
+command=env -i /patroni_wait.sh --role master -- /usr/bin/pgqd /home/postgres/pgq_ticker.ini
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+exitcodes=0,2

--- a/postgres-appliance/supervisor.d/pgq.conf
+++ b/postgres-appliance/supervisor.d/pgq.conf
@@ -2,8 +2,7 @@
 priority=999
 directory=/
 user=postgres
-environment=PGAPPNAME="pgq ticker"
-command=env -i /patroni_wait.sh --role master -- /usr/bin/pgqd /home/postgres/pgq_ticker.ini
+command=env -i PGAPPNAME="pgq ticker" /patroni_wait.sh --role master -- /usr/bin/pgqd /home/postgres/pgq_ticker.ini
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 redirect_stderr=true


### PR DESCRIPTION
Some teams require pgq to run. After some analysis it shows pgq
can be added without a lot of configuration. Adding the pgq
extension will be picked up by pgq within a few minutes.

To reduce logging noise, we do prepend it with patroni_wait