### PR TITLE
Reduce the pool size for backup

### DIFF
--- a/postgres-appliance/postgres_backup.sh
+++ b/postgres-appliance/postgres_backup.sh
@@ -22,6 +22,10 @@ IN_RECOVERY=$(psql -tXqAc "select pg_is_in_recovery()")
 # leave only 2 base backups before creating a new one
 envdir "${WALE_ENV_DIR}" wal-e --aws-instance-profile delete --confirm retain 2
 
+# Ensure we don't have more workes than CPU's
+POOL_SIZE=4
+[ $(nproc) -lt $POOL_SIZE ] && POOL_SIZE=$(nproc)
+
 # push a new base backup
 log "producing a new backup"
-exec envdir "${WALE_ENV_DIR}" wal-e --aws-instance-profile backup-push "${PGDATA}"
+exec envdir "${WALE_ENV_DIR}" wal-e --aws-instance-profile backup-push "${PGDATA}" --pool-size ${POOL_SIZE}


### PR DESCRIPTION
The default pool size for WAL-E is 4, we've seen some Spilo appliances
failover during the backup. During the backup, the CPU utilization was very
high and the lock in etcd was not updated on time.

To reduce stress on systems with less cores, we will reduce the pool size
if the number of cores is small