### PR TITLE
Ensure ownership of PGDATA

### DIFF
--- a/postgres-appliance/launch.sh
+++ b/postgres-appliance/launch.sh
@@ -3,6 +3,8 @@
 pgrep supervisord > /dev/null
 if [ $? -ne 1 ]; then echo "ERROR: Supervisord is already running"; exit 1; fi
 
+[ -d "$PGDATA" ] && chown -R postgres:postgres "$PGDATA"
+
 python /configure_spilo.py all
 (
     sudo PATH="$PATH" -u postgres /patroni_wait.sh -t 3600 -- /postgres_backup.sh "$WALE_ENV_DIR" "$PGDATA"


### PR DESCRIPTION
When restoring from an EBS Snapshot, it may happen that the PGDATA
directory (and files) is owned by another user. This fixes that.