### PR TITLE
Always define etcd scope as string

### DIFF
--- a/postgres-appliance/configure_spilo.py
+++ b/postgres-appliance/configure_spilo.py
@@ -241,7 +241,7 @@ zookeeper:
   session_timeout: {ttl}
   reconnect_timeout: {loop_wait}
 etcd:
-  scope: {scope}
+  scope: '{scope}'
   ttl: {ttl}'''.format(**config))
 
     config = {}


### PR DESCRIPTION
If you use a stack version, which is only composed of numbers, Python will also treat this as a number and the following exception happens when starting patroni:

```python
Traceback (most recent call last):
  File "/usr/local/bin/patroni", line 9, in <module>
    load_entry_point('patroni==0.90', 'console_scripts', 'patroni')()
  File "/usr/local/lib/python2.7/dist-packages/patroni/__init__.py", line 98, in main
    patroni = Patroni(config)
  File "/usr/local/lib/python2.7/dist-packages/patroni/__init__.py", line 25, in __init__
    self.dcs = self.get_dcs(self.postgresql.name, config)
  File "/usr/local/lib/python2.7/dist-packages/patroni/__init__.py", line 47, in get_dcs
    return Etcd(name, config['etcd'])
  File "/usr/local/lib/python2.7/dist-packages/patroni/etcd.py", line 195, in __init__
    super(Etcd, self).__init__(name, config)
  File "/usr/local/lib/python2.7/dist-packages/patroni/dcs.py", line 185, in __init__
    self._base_path = '/'.join([self._namespace, config['scope']])
TypeError: sequence item 1: expected string, int found
```