### PR TITLE
Re-enable dynamic tuning of shared_buffers

### DIFF
--- a/postgres-appliance/configure_spilo.py
+++ b/postgres-appliance/configure_spilo.py
@@ -111,7 +111,7 @@ bootstrap:
         wal_keep_segments: 8
         wal_log_hints: 'on'
         max_wal_senders: 5
-        shared_buffers: 500MB
+        shared_buffers: {{postgresql.parameters.shared_buffers}}
         max_connections: {{postgresql.parameters.max_connections}}
         max_replication_slots: 5
         hot_standby: 'on'

--- a/postgres-appliance/configure_spilo.py
+++ b/postgres-appliance/configure_spilo.py
@@ -111,7 +111,6 @@ bootstrap:
         wal_keep_segments: 8
         wal_log_hints: 'on'
         max_wal_senders: 5
-        shared_buffers: {{postgresql.parameters.shared_buffers}}
         max_connections: {{postgresql.parameters.max_connections}}
         max_replication_slots: 5
         hot_standby: 'on'
@@ -153,6 +152,8 @@ postgresql:
   listen: 0.0.0.0:{{PGPORT}}
   connect_address: {{instance_data.ip}}:{{PGPORT}}
   data_dir: {{PGDATA}}
+  parameters:
+    shared_buffers: {{postgresql.parameters.shared_buffers}}
   authentication:
     superuser:
       username: postgres


### PR DESCRIPTION
In commit c74a62f4fcc448069f5e9a579322ea6deec1bdc5 the configuration was changed to a Patroni 1.0 compatible
configuration. However, shared_buffers was pinned to 500MB with this.