### PR TITLE
Use the bucket region for WAL-E Endpoint

### DIFF
--- a/postgres-appliance/configure_spilo.py
+++ b/postgres-appliance/configure_spilo.py
@@ -348,7 +348,12 @@ def write_wale_command_environment(placeholders, overwrite, provider):
     if provider == PROVIDER_AWS:
         write_file('s3://{WAL_S3_BUCKET}/spilo/{SCOPE}/wal/'.format(**placeholders),
                    os.path.join(placeholders['WALE_ENV_DIR'], 'WALE_S3_PREFIX'), overwrite)
-        write_file('https+path://s3-{}.amazonaws.com:443'.format(placeholders['instance_data']['zone'][:-1]),
+        match = re.search(r'.*(eu-\w+-\d+)-.*', placeholders['WAL_S3_BUCKET'])
+        if match:
+            region = match.group(1)
+        else:
+            region = get_instance_meta_data('placement/availability-zone')[:-1]
+        write_file('https+path://s3-{}.amazonaws.com:443'.format(region),
                    os.path.join(placeholders['WALE_ENV_DIR'], 'WALE_S3_ENDPOINT'), overwrite)
     elif provider == PROVIDER_GOOGLE:
         write_file('gs://{WAL_GCS_BUCKET}/spilo/{SCOPE}/wal/'.format(**placeholders),


### PR DESCRIPTION
When doing cross-region replication, it may occur that WAL-E requests s3 objects
from a different region. By default, WAL-E is configured to connect to the endpoint
of the region where it is running.
This patch changes the logic so that we choose the endpoint based upon the name
of the bucket. If that fails, we use the previous behaviour.