### PR TITLE
Spin up local etcd if DEVELOP is specified

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -76,7 +76,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 # install etcdctl
 ENV ETCDVERSION 2.3.7
 RUN curl -L https://github.com/coreos/etcd/releases/download/v${ETCDVERSION}/etcd-v${ETCDVERSION}-linux-amd64.tar.gz \
-    | tar xz -C /bin --strip=1 --wildcards --no-anchored etcdctl
+    | tar xz -C /bin --strip=1 --wildcards --no-anchored etcdctl etcd
 
 ENV PGHOME=/home/postgres
 ENV PGROOT=$PGHOME/pgdata/pgroot


### PR DESCRIPTION
Multiple developers have asked for a Spilo like environment including pgq,
postgis etc.
By starting up etcd if DEVELOP is specified, we can easily ask people to deploy against
what we actually run in production.