### PR TITLE
Bump upstream versions

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -50,8 +50,8 @@ ENV PATH=$PATH:/usr/lib/postgresql/${PGVERSION}/bin
 ## 1 Install tools required to build
 ## 2 Build
 ## 3 Remove tools only required for build
-ENV PATRONIVERSION=1.0
-ENV WALE_VERSION=1.0.0a2
+ENV PATRONIVERSION=1.1
+ENV WALE_VERSION=1.0.0b1
 RUN export DEBIAN_FRONTEND=noninteractive \
     export BUILD_PACKAGES="postgresql-server-dev-${PGVERSION} python3-pip python3-dev build-essential pgxnclient" \
     export PGXN_EXTENSIONS="quantile trimmed_aggregates" \

--- a/postgres-appliance/configure_spilo.py
+++ b/postgres-appliance/configure_spilo.py
@@ -447,7 +447,7 @@ def main():
     logging.basicConfig(format='%(asctime)s - bootstrapping - %(levelname)s - %(message)s', level=('DEBUG'
                         if debug else (args.get('loglevel') or 'INFO').upper()))
 
-    if float(os.environ.get('PATRONIVERSION')) < 1.0:
+    if os.environ.get('PATRONIVERSION') < '1.0':
         raise Exception('Patroni version >= 1.0 is required')
 
     provider = get_provider()


### PR DESCRIPTION
Also ensure we can compare non-numeric (e.g. 1.1rc1 <> 1.0) versions
for Patroni