### PR TITLE
Create a directory for storing logs of PostgreSQL

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -81,6 +81,7 @@ RUN curl -L https://github.com/coreos/etcd/releases/download/v${ETCDVERSION}/etc
 ENV PGHOME=/home/postgres
 ENV PGROOT=$PGHOME/pgdata/pgroot
 ENV PGDATA=$PGROOT/data
+ENV PGLOG=$PGROOT/pg_log
 ENV WALE_ENV_DIR=$PGHOME/etc/wal-e.d/env
 
 # Set PGHOME as a login directory for the PostgreSQL user.

--- a/postgres-appliance/launch.sh
+++ b/postgres-appliance/launch.sh
@@ -4,6 +4,7 @@ pgrep supervisord > /dev/null
 if [ $? -ne 1 ]; then echo "ERROR: Supervisord is already running"; exit 1; fi
 
 mkdir -p "$PGROOT" && chown -R postgres:postgres "$PGROOT"
+mkdir -p "$PGLOG" && chown -R postgres:postgres "$PGLOG"
 
 python3 /configure_spilo.py all
 (


### PR DESCRIPTION
Some Spilo's currently log to the filesystem inside docker. If these
files are stored inside $PGDATA, they are also part of any basebackup or WAL-E backup.
When these files grow big, WAL-E fails to backup, because it assumes no files inside $PGDATA
are bigger than 1.5GB.

There now is a pull request to address this at the WAL-E level: https://github.com/wal-e/wal-e/pull/278
however, it seems usefull to allow logs to persist outside the $PGDATA directory.

This only creates the directory, it does not configure PostgreSQL to actually use this directory, that task
is for the senza template.