### PR TITLE
Catch more errors when trying to figure out environment

### DIFF
--- a/postgres-appliance/configure_spilo.py
+++ b/postgres-appliance/configure_spilo.py
@@ -209,7 +209,7 @@ def get_provider():
                 return PROVIDER_AWS
             else:
                 return PROVIDER_UNSUPPORTED
-    except requests.exceptions.ConnectTimeout:
+    except (requests.exceptions.ConnectTimeout, requests.exceptions.ConnectionError):
         logging.info("Could not connect to 169.254.169.254, assuming local Docker setup")
         return PROVIDER_LOCAL
 


### PR DESCRIPTION
More errors can occur on (local) environments which would signify
that the container is not running in a cloud environment.

An example is:

```text
2016-09-12 21:36:32,426 - bootstrapping - INFO - Figuring out my environment (Google? AWS? Local?)
2016-09-12 21:36:32,432 - bootstrapping - INFO - Starting new HTTP connection (1): 169.254.169.254
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/dist-packages/requests/packages/urllib3/connection.py", line 142, in _new_conn
    (self.host, self.port), self.timeout, **extra_kw)
  File "/usr/local/lib/python3.4/dist-packages/requests/packages/urllib3/util/connection.py", line 98, in create_connection
    raise err
  File "/usr/local/lib/python3.4/dist-packages/requests/packages/urllib3/util/connection.py", line 88, in create_connection
    sock.connect(sa)
ConnectionRefusedError: [Errno 111] Connection refused

During handling of the above exception, another exception occurred:
```

By catching more errors we should address this issue.