### PR TITLE
Ensure postgresql logfiles all exist

### DIFF
--- a/postgres-appliance/launch.sh
+++ b/postgres-appliance/launch.sh
@@ -8,7 +8,7 @@ mkdir -p "$PGLOG" && chown -R postgres:postgres "$PGLOG"
 
 ## Ensure all logfiles exist, most appliances will have
 ## a foreign data wrapper pointing to these files
-for i in $(seq 0 6); do touch "${PGLOG}/postgresql-$i.csv"; done
+for i in $(seq 0 7); do touch "${PGLOG}/postgresql-$i.csv"; done
 
 python3 /configure_spilo.py all
 (

--- a/postgres-appliance/launch.sh
+++ b/postgres-appliance/launch.sh
@@ -6,6 +6,10 @@ if [ $? -ne 1 ]; then echo "ERROR: Supervisord is already running"; exit 1; fi
 mkdir -p "$PGROOT" && chown -R postgres:postgres "$PGROOT"
 mkdir -p "$PGLOG" && chown -R postgres:postgres "$PGLOG"
 
+## Ensure all logfiles exist, most appliances will have
+## a foreign data wrapper pointing to these files
+for i in $(seq 0 6); do touch "${PGLOG}/postgresql-$i.csv"; done
+
 python3 /configure_spilo.py all
 (
     sudo PATH="$PATH" -u postgres /patroni_wait.sh -t 3600 -- /postgres_backup.sh "$WALE_ENV_DIR" "$PGDATA"


### PR DESCRIPTION
When using foreign data wrappers pointing to the logfiles, they
may error out if the logfiles do not exist (yet).
By touching the files, we ensure they exist so these data wrappers will work file
as well.