### PR TITLE
Ensure the logfiles are owned by postgres

### DIFF
--- a/postgres-appliance/launch.sh
+++ b/postgres-appliance/launch.sh
@@ -4,11 +4,12 @@ pgrep supervisord > /dev/null
 if [ $? -ne 1 ]; then echo "ERROR: Supervisord is already running"; exit 1; fi
 
 mkdir -p "$PGROOT" && chown -R postgres:postgres "$PGROOT"
-mkdir -p "$PGLOG" && chown -R postgres:postgres "$PGLOG"
+mkdir -p "$PGLOG"
 
 ## Ensure all logfiles exist, most appliances will have
 ## a foreign data wrapper pointing to these files
 for i in $(seq 0 7); do touch "${PGLOG}/postgresql-$i.csv"; done
+chown -R postgres:postgres "$PGLOG"
 
 python3 /configure_spilo.py all
 (


### PR DESCRIPTION
If PostgreSQL cannot write to the csv logs it will flood its diagnostic log.
This has already happened and can write > 100GB within a night.