### PR TITLE
Use PROVIDER_LOCAL when DEVELOP env is set

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -32,7 +32,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
             # Install PostgreSQL binaries, contrib, pgq, plproxy, pgq and multiple pl's
             apt-get install -y postgresql-${version} postgresql-${version}-dbg postgresql-client-${version} \
                         postgresql-contrib-${version} postgresql-${version}-plproxy postgresql-${version}-pgq3 \
-                        postgresql-${version}-postgis postgresql-plpython3-${version} \
+                        postgresql-${version}-postgis-2.3 postgresql-plpython3-${version} \
                         postgresql-plpython-${version} postgresql-${version}-plr postgresql-pltcl-${version} \
                         postgresql-${version}-plv8 postgresql-${version}-pllua postgresql-plperl-${version} \
             # Remove the default cluster, which Debian stupidly starts right after installation of the packages

--- a/postgres-appliance/configure_spilo.py
+++ b/postgres-appliance/configure_spilo.py
@@ -352,7 +352,7 @@ def write_wale_command_environment(placeholders, overwrite, provider):
         if match:
             region = match.group(1)
         else:
-            region = get_instance_meta_data('placement/availability-zone')[:-1]
+            region = get_instance_metadata('placement/availability-zone')[:-1]
         write_file('https+path://s3-{}.amazonaws.com:443'.format(region),
                    os.path.join(placeholders['WALE_ENV_DIR'], 'WALE_S3_ENDPOINT'), overwrite)
     elif provider == PROVIDER_GOOGLE:
@@ -450,11 +450,13 @@ def main():
     if os.environ.get('PATRONIVERSION') < '1.0':
         raise Exception('Patroni version >= 1.0 is required')
 
-    provider = get_provider()
-    placeholders = get_placeholders(provider)
-
-    if os.environ.get('DEVELOP', '') in ['1', 'true', 'on', 'ON']:
+    if os.environ.get('DEVELOP', '').lower() in ['1', 'true', 'on']:
         write_etcd_configuration(placeholders)
+        provider = PROVIDER_LOCAL
+    else:
+        provider = get_provider()
+
+    placeholders = get_placeholders(provider)
 
     config = yaml.load(pystache_render(TEMPLATE, placeholders))
     config.update(get_dcs_config(config, placeholders))


### PR DESCRIPTION
It doesn't make much sense determining provider in this case.
Also it will make it possible to run spilo as standalone app on AWS with
for example jenkins.