### PR TITLE
Configuration can be set with $SPILO_CONFIGURATION.

### DIFF
--- a/postgres-appliance/configure_spilo.py
+++ b/postgres-appliance/configure_spilo.py
@@ -333,7 +333,7 @@ etcd:
         config = {'etcd': defaults['etcd']}
         config['etcd']['discovery_srv'] = placeholders['ETCD_DISCOVERY_DOMAIN']
     else:
-        pass  # Configuration can also be specified using PATRONI_CONFIGURATION
+        pass  # Configuration can also be specified using either SPILO_CONFIGURATION or PATRONI_CONFIGURATION
 
     return config
 
@@ -459,9 +459,10 @@ def main():
     config = yaml.load(pystache_render(TEMPLATE, placeholders))
     config.update(get_dcs_config(config, placeholders))
 
-    user_config = yaml.load(os.environ.get('PATRONI_CONFIGURATION', '')) or {}
+    user_config = yaml.load(os.environ.get('SPILO_CONFIGURATION', os.environ.get('PATRONI_CONFIGURATION', ''))) or {}
     if not isinstance(user_config, dict):
-        raise ValueError('PATRONI_CONFIGURATION should contain a dict, yet it is a {}'.format(type(user_config)))
+        config_var_name = 'SPILO_CONFIGURATION' if 'SPILO_CONFIGURATION' in os.environ else 'PATRONI_CONFIGURATION'
+        raise ValueError('{0} should contain a dict, yet it is a {}'.format(config_var_name, type(user_config)))
 
     config = deep_update(user_config, config)
 


### PR DESCRIPTION
Previously, Spilo used PATRONI_CONFIGURATION in order to read the
non-default configuration for Patroni (the default one is hard-coded
in the configure_spilo.py. Because the envionment variable with the
same name is also used by Patroni for a completely different purpose,
it lead to a conflict that was hard to debug. Therefore, we need to
rename it, but in order to keep the compatibility with the already
deployed clusters, both the old and the new (SPILO_CONFIGURATION)
names will be accepted by the Docker image with the preference for
the new one if both are set. That will allow us to change the
deployment configuration to use the new name without breaking already
deployed clusters in the case we will need to update their configuration
on the fly.

This should fix #102 