### PR TITLE
Set different TMPDIR for wal-e and install pg_view

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -78,6 +78,11 @@ ENV ETCDVERSION 2.3.7
 RUN curl -L https://github.com/coreos/etcd/releases/download/v${ETCDVERSION}/etcd-v${ETCDVERSION}-linux-amd64.tar.gz \
     | tar xz -C /bin --strip=1 --wildcards --no-anchored etcdctl etcd
 
+
+#install pg_view
+RUN curl -L https://raw.githubusercontent.com/zalando/pg_view/master/pg_view.py \
+    | sed -e 's/env python/env python3/g' > /usr/local/bin/pg_view.py && chmod +x /usr/local/bin/pg_view.py
+
 ENV PGHOME=/home/postgres
 ENV PGROOT=$PGHOME/pgdata/pgroot
 ENV PGDATA=$PGROOT/data
@@ -93,6 +98,7 @@ ADD stunnel.d /etc/stunnel
 ADD pgq_ticker.ini $PGHOME
 ADD motd /etc/
 RUN echo "source /etc/motd" >> /root/.bashrc
+RUN echo "export TERM=linux\nexport LC_ALL=C.UTF-8\nexport LANG=C.UTF-8" >> /etc/bash.bashrc
 RUN chmod 700 /postgres_*
 
 ENV ETCD_DISCOVERY_DOMAIN=postgres.acid.example.com LC_ALL=en_US.utf-8

--- a/postgres-appliance/configure_spilo.py
+++ b/postgres-appliance/configure_spilo.py
@@ -251,6 +251,7 @@ def get_placeholders(provider):
     placeholders.setdefault('BACKUP_SCHEDULE', '00 01 * * *')
     placeholders.setdefault('CRONTAB', '[]')
     placeholders.setdefault('PGROOT', os.path.join(placeholders['PGHOME'], 'pgroot'))
+    placeholders.setdefault('WALE_TMPDIR', os.path.abspath(os.path.join(placeholders['PGROOT'], '../tmp')))
     placeholders.setdefault('PGDATA', os.path.join(placeholders['PGROOT'], 'pgdata'))
     placeholders.setdefault('PGPASSWORD_ADMIN', 'standby')
     placeholders.setdefault('PGPASSWORD_STANDBY', 'standby')
@@ -293,7 +294,6 @@ def get_placeholders(provider):
     placeholders['postgresql']['parameters']['max_connections'] = min(max(100, int(os_memory_mb/30)), 1000)
 
     placeholders['instance_data'] = get_instance_metadata(provider)
-    placeholders['instance_data']['id'] = re.sub(r'\W+', '_', placeholders['instance_data']['id'])
     return placeholders
 
 
@@ -365,6 +365,10 @@ def write_wale_command_environment(placeholders, overwrite, provider):
         if placeholders['GOOGLE_APPLICATION_CREDENTIALS']:
             write_file('{GOOGLE_APPLICATION_CREDENTIALS}'.format(**placeholders),
                        os.path.join(placeholders['WALE_ENV_DIR'], 'GOOGLE_APPLICATION_CREDENTIALS'), overwrite)
+    else:
+        return
+    os.makedirs(placeholders['WALE_TMPDIR'])
+    write_file(placeholders['WALE_TMPDIR'], os.path.join(placeholders['WALE_ENV_DIR'], 'TMPDIR'), True)
 
 
 def write_crontab(placeholders, path, overwrite):


### PR DESCRIPTION
TMPDIR for wal-e will be located on separate volume.
In addition to that export necessary env variables to make pg_view and
patronictl work when you run them with docker exec