### PR TITLE
Some optimisations around restore_command = wal-e

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -103,7 +103,7 @@ ENV WALE_ENV_DIR=$PGHOME/etc/wal-e.d/env
 # Set PGHOME as a login directory for the PostgreSQL user.
 RUN usermod -d $PGHOME -m postgres
 
-ADD scm-source.json configure_spilo.py launch.sh postgres_backup.sh patroni_wait.sh post_init.sh _zmon_schema.dump callback_role.py /
+ADD scm-source.json configure_spilo.py launch.sh postgres_backup.sh patroni_wait.sh post_init.sh _zmon_schema.dump callback_role.py basebackup.sh wale_restore_command.sh /
 ADD supervisor.d /etc/supervisor/conf.d/
 ADD stunnel.d /etc/stunnel
 ADD pgq_ticker.ini $PGHOME

--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -8,7 +8,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && echo 'APT::Install-Suggests "0";' >> /etc/apt/apt.conf.d/01norecommend \
 
     && apt-get upgrade -y \
-    && apt-get install -y curl ca-certificates jq pv vim gdb strace supervisor stunnel \
+    && apt-get install -y curl ca-certificates jq pv vim gdb strace supervisor stunnel realpath \
 
     ## Make sure we have a en_US.UTF-8 locale available
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \

--- a/postgres-appliance/basebackup.sh
+++ b/postgres-appliance/basebackup.sh
@@ -34,6 +34,7 @@ while [[ $((ATTEMPT++)) -le $RETRIES ]]; do
     EXITCODE=$?
     if [[ $EXITCODE == 0 ]]; then
         XLOG_FAST=$(dirname $DATA_DIR)/xlog_fast
+        rm -fr $XLOG_FAST
         mv ${DATA_DIR}/pg_xlog $XLOG_FAST
         rm -fr $XLOG_FAST/archive_status
         break

--- a/postgres-appliance/basebackup.sh
+++ b/postgres-appliance/basebackup.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+RETRIES=3
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --datadir )
+            DATA_DIR=$2
+            shift
+            ;;
+        --connstring )
+            CONNSTR=$2
+            shift
+            ;;
+        --retries )
+            RETRIES=$2
+            shift
+            ;;
+        * )
+            ;;
+    esac
+    shift
+done
+
+[[ -z $DATA_DIR || -z $CONNSTR || ! $RETRIES =~ ^[1-9]$ ]] && exit 1
+
+DATA_DIR=$(realpath $DATA_DIR)
+XLOG_DIR=$(dirname $DATA_DIR)/xlog_fast
+
+ATTEMPT=0
+EXITCODE=1
+while [[ $((ATTEMPT++)) < $RETRIES || $EXITCODE == 0 ]]; do
+    pg_basebackup -P --pgdata="${DATA_DIR}" --xlog-method=stream --xlogdir="${XLOG_DIR}" --dbname="${CONNSTR}"
+    EXITCODE=$?
+done
+exit $EXITCODE

--- a/postgres-appliance/basebackup.sh
+++ b/postgres-appliance/basebackup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RETRIES=3
+RETRIES=2
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -29,8 +29,8 @@ XLOG_DIR=$(dirname $DATA_DIR)/xlog_fast
 
 ATTEMPT=0
 EXITCODE=1
-while [[ $((ATTEMPT++)) < $RETRIES || $EXITCODE == 0 ]]; do
-    pg_basebackup -P --pgdata="${DATA_DIR}" --xlog-method=stream --xlogdir="${XLOG_DIR}" --dbname="${CONNSTR}"
+while [[ $((ATTEMPT++)) -le $RETRIES || $EXITCODE == 0 ]]; do
+    pg_basebackup --pgdata="${DATA_DIR}" --xlog-method=stream --xlogdir="${XLOG_DIR}" --dbname="${CONNSTR}"
     EXITCODE=$?
 done
 exit $EXITCODE

--- a/postgres-appliance/configure_spilo.py
+++ b/postgres-appliance/configure_spilo.py
@@ -140,10 +140,6 @@ bootstrap:
         autovacuum_max_workers: 5
         autovacuum_vacuum_scale_factor: 0.05
         autovacuum_analyze_scale_factor: 0.02
-      {{#USE_WALE}}
-      recovery_conf:
-        restore_command: envdir "{{WALE_ENV_DIR}}" /wale_restore_command.sh "%f" "%p"
-      {{/USE_WALE}}
   initdb:
   - encoding: UTF8
   - locale: en_US.UTF-8
@@ -178,6 +174,10 @@ postgresql:
     ssl: 'on'
     ssl_cert_file: {{SSL_CERTIFICATE_FILE}}
     ssl_key_file: {{SSL_PRIVATE_KEY_FILE}}
+  {{#USE_WALE}}
+  recovery_conf:
+    restore_command: envdir "{{WALE_ENV_DIR}}" /wale_restore_command.sh "%f" "%p"
+  {{/USE_WALE}}
   authentication:
     superuser:
       username: postgres

--- a/postgres-appliance/configure_spilo.py
+++ b/postgres-appliance/configure_spilo.py
@@ -142,7 +142,7 @@ bootstrap:
         autovacuum_analyze_scale_factor: 0.02
       {{#USE_WALE}}
       recovery_conf:
-        restore_command: envdir "{{WALE_ENV_DIR}}" /wale_restore_command.sh
+        restore_command: envdir "{{WALE_ENV_DIR}}" /wale_restore_command.sh "%f" "%p"
       {{/USE_WALE}}
   initdb:
   - encoding: UTF8
@@ -211,6 +211,7 @@ postgresql:
     no_master: 1
   basebackup_fast_xlog:
     command: /basebackup.sh
+    retries: 2
 {{/USE_WALE}}
 '''
 

--- a/postgres-appliance/configure_spilo.py
+++ b/postgres-appliance/configure_spilo.py
@@ -142,7 +142,7 @@ bootstrap:
         autovacuum_analyze_scale_factor: 0.02
       {{#USE_WALE}}
       recovery_conf:
-        restore_command: envdir "{{WALE_ENV_DIR}}" wal-e --aws-instance-profile wal-fetch "%f" "%p"
+        restore_command: envdir "{{WALE_ENV_DIR}}" /wale_restore_command.sh
       {{/USE_WALE}}
   initdb:
   - encoding: UTF8
@@ -195,8 +195,11 @@ postgresql:
   create_replica_method:
     {{#USE_WALE}}
     - wal_e
+    - basebackup_fast_xlog
     {{/USE_WALE}}
+    {{^USE_WALE}}
     - basebackup
+    {{/USE_WALE}}
  {{#USE_WALE}}
   wal_e:
     command: patroni_wale_restore
@@ -206,6 +209,8 @@ postgresql:
     use_iam: 1
     retries: 2
     no_master: 1
+  basebackup_fast_xlog:
+    command: /basebackup.sh
 {{/USE_WALE}}
 '''
 

--- a/postgres-appliance/wale_restore_command.sh
+++ b/postgres-appliance/wale_restore_command.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+readonly xlog_filename=$1
+readonly xlog_destination=$2
+
+[[ -z $xlog_filename || -z $xlog_destination ]] && exit 1
+
+readonly xlog_dir=$(dirname $xlog_destination)
+readonly xlog_fast_source=$(dirname $(dirname $(realpath $xlog_dir)))/xlog_fast/$xlog_filename
+readonly wale_prefetch_source=${xlog_dir}/.wal-e/prefetch/${xlog_filename}
+
+if [[ -f $xlog_fast_source ]]; then
+    exec mv "${xlog_fast_source}" "${xlog_destination}"
+elif [[ -f $wale_prefetch_source ]]; then
+    exec mv "${wale_prefetch_source}" "${xlog_destination}"
+else
+    exec wal-e --aws-instance-profile wal-fetch "${xlog_filename}" "${xlog_destination}"
+fi


### PR DESCRIPTION
1) wal-e wal-fetch is incredibly slow
2) When we start postgres it will call the restore_command for every
xlog segment needed to reach consistent state even if there is a valid
file in the pg_xlog dicrectory.
3) Even if the wal-e is prefetching wal segments it it is rather
expencive to move them into pg_xlog by wal-e.

All these facts are making useless streaming of xlogs with pg_basebackup,
because afterwards it will call restore_command anyway :(

In order to optimize this process we will stream xlogs not into default
pg_xlog but into separate directory and create a wrapper restore_command
script, which will:
Check if there is xlog already available on disk either in directory
created by pg_basebackup or in the pg_xlog/.wal-e/prefetch directory.
If the file is there - just move it. If it is not - call wal-e with
usual options.