### PR TITLE
Enable checksums by default for new clusters.

### DIFF
--- a/postgres-appliance/configure_spilo.py
+++ b/postgres-appliance/configure_spilo.py
@@ -143,6 +143,7 @@ bootstrap:
   initdb:
   - encoding: UTF8
   - locale: en_US.UTF-8
+  - data-checksums
   users:
     admin:
       password: {{PGPASSWORD_ADMIN}}


### PR DESCRIPTION
Because of the data corruption issues (https://wiki.postgresql.org/wiki/Visibility_Map_Problems, https://wiki.postgresql.org/wiki/Free_Space_Map_Problems), for  the first one there is no reliable way to detect the affected pre-9.6 clusters. 

It gives us ~ 2% performance hit according to http://blog.endpoint.com/2015/12/postgres-checksum-performance-impact.html, but the data integrity deems more important  that maximum possible performance (after all, we are not running with fsync=off).