### PR TITLE
Assign the name for the endpoint port.

### DIFF
--- a/postgres-appliance/callback_role.py
+++ b/postgres-appliance/callback_role.py
@@ -63,7 +63,7 @@ def change_pod_role_label(namespace, new_role):
 
 def change_endpoints(namespace, cluster):
     ip = os.environ.get('POD_IP', socket.gethostbyname(socket.gethostname()))
-    body = json.dumps({'subsets': [{'addresses': [{'ip': ip}], 'ports': [{'port': 5432, 'protocol': 'TCP'}]}]})
+    body = json.dumps({'subsets': [{'addresses': [{'ip': ip}], 'ports': [{'name': 'postgresql', 'port': 5432, 'protocol': 'TCP'}]}]})
     api_patch(namespace, 'endpoints', cluster, 'service endpoints', body)
 
 


### PR DESCRIPTION
In Kubernetes 1.6 each port defined by a service should have a
name. The same, apparently, applies to the endpoints connected
to those services.