### PR TITLE
BUGFIX: add missing sudo

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -8,7 +8,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
     && apt-get upgrade -y \
     # Install cron, curl, jq, vim, gdb, strace
-    && apt-get install -y cron curl ca-certificates less jq pv vim gdb strace supervisor stunnel \
+    && apt-get install -y cron curl ca-certificates less jq pv vim gdb sudo strace supervisor stunnel \
 
     ## Make sure we have a en_US.UTF-8 locale available
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \


### PR DESCRIPTION
Traceback (most recent call last):
  File "/configure_spilo.py", line 533, in <module>
    main()
  File "/configure_spilo.py", line 520, in main
    write_crontab(placeholders, os.environ.get('PATH'), args['force'])
  File "/configure_spilo.py", line 385, in write_crontab
    cron_exit = subprocess.call(['sudo', '-u', 'postgres', 'crontab', '-l'], stdout=devnull, stderr=devnull)
  File "/usr/lib/python3.5/subprocess.py", line 557, in call
    with Popen(*popenargs, **kwargs) as p:
  File "/usr/lib/python3.5/subprocess.py", line 947, in __init__
    restore_signals, start_new_session)
  File "/usr/lib/python3.5/subprocess.py", line 1551, in _execute_child
    raise child_exception_type(errno_num, err_msg)
FileNotFoundError: [Errno 2] No such file or directory: 'sudo'