### PR TITLE
Make sure 'locales' package is installed

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -8,7 +8,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
     && apt-get upgrade -y \
     # Install cron, curl, jq, vim, gdb, strace
-    && apt-get install -y cron curl ca-certificates less jq pv vim gdb sudo strace supervisor stunnel \
+    && apt-get install -y cron curl ca-certificates less locales jq pv vim gdb sudo strace supervisor stunnel \
 
     ## Make sure we have a en_US.UTF-8 locale available
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \


### PR DESCRIPTION
The most recent ubuntu:16.04 image
(ubuntu@sha256:c2bbf50d276508d73dd865cda7b4ee9b5243f2648647d21e3a471dd3cc4209a0)
does not have the "locales" package installed, which results in the following
error message:

     character map file `UTF-8' not found: No such file or directory
     cannot read character map directory `/usr/share/i18n/charmaps': No such file or directory