### PR TITLE
Enable disabling Dockerfile dependency on scm-source.json

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -159,7 +159,9 @@ ENV WALE_ENV_DIR=$PGHOME/etc/wal-e.d/env
 # Set PGHOME as a login directory for the PostgreSQL user.
 RUN usermod -d $PGHOME -m postgres
 
-ADD scm-source.json configure_spilo.py launch.sh postgres_backup.sh patroni_wait.sh post_init.sh _zmon_schema.dump callback_role.py basebackup.sh wale_restore_command.sh /
+ARG SCM_SOURCE=
+
+ADD ${SCM_SOURCE} configure_spilo.py launch.sh postgres_backup.sh patroni_wait.sh post_init.sh _zmon_schema.dump callback_role.py basebackup.sh wale_restore_command.sh /
 ADD supervisor.d /etc/supervisor/conf.d/
 ADD stunnel.d /etc/stunnel
 ADD pgq_ticker.ini $PGHOME

--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -159,7 +159,7 @@ ENV WALE_ENV_DIR=$PGHOME/etc/wal-e.d/env
 # Set PGHOME as a login directory for the PostgreSQL user.
 RUN usermod -d $PGHOME -m postgres
 
-ARG SCM_SOURCE=scm-source.json
+ARG SCM_SOURCE=
 
 ADD ${SCM_SOURCE} configure_spilo.py launch.sh postgres_backup.sh patroni_wait.sh post_init.sh _zmon_schema.dump callback_role.py basebackup.sh wale_restore_command.sh /
 ADD supervisor.d /etc/supervisor/conf.d/

--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -159,7 +159,7 @@ ENV WALE_ENV_DIR=$PGHOME/etc/wal-e.d/env
 # Set PGHOME as a login directory for the PostgreSQL user.
 RUN usermod -d $PGHOME -m postgres
 
-ARG SCM_SOURCE=
+ARG SCM_SOURCE=scm-source.json
 
 ADD ${SCM_SOURCE} configure_spilo.py launch.sh postgres_backup.sh patroni_wait.sh post_init.sh _zmon_schema.dump callback_role.py basebackup.sh wale_restore_command.sh /
 ADD supervisor.d /etc/supervisor/conf.d/


### PR DESCRIPTION
scm-source.json is not included in the source, nor produced automatically by spilo alone. My quick solution is to use docker's build-args to be able to disable the inclusion of it by building with `--build-arg SCM_SOURCE=`.

I am trying to use spilo on Kubernetes/GKE, I am not using STUPS or anything similar, nor am I familiar enough with STUPS to know if STUPS would produce it automatically. Thus, in my scenario the dependency of `docker build -t spilo postgres-appliance` on `scm-source.json` seems unnecessary.

In my scenario, a better solution  would be to either drop the dependency on `scm-source.json` or create it automatically - Creating it automatically might be harder to get right for everyone, and probably harder to fix when it does wrong.