### PR TITLE
BUGFIX: get available memory from memory.limit_in_bytes

### DIFF
--- a/postgres-appliance/configure_spilo.py
+++ b/postgres-appliance/configure_spilo.py
@@ -21,8 +21,7 @@ PROVIDER_GOOGLE = "google"
 PROVIDER_LOCAL = "local"
 PROVIDER_UNSUPPORTED = "unsupported"
 USE_KUBERNETES = os.environ.get('KUBERNETES_SERVICE_HOST') is not None
-MEMORY_LIMIT_IN_BYTES_PATH="/sys/fs/cgroup/memory/memory.max_usage_in_bytes"
-
+MEMORY_LIMIT_IN_BYTES_PATH = '/sys/fs/cgroup/memory/memory.limit_in_bytes'
 
 def parse_args():
     sections = ['all', 'patroni', 'patronictl', 'certificate', 'wal-e', 'crontab', 'ldap', 'pam-oauth2']


### PR DESCRIPTION
/sys/fs/cgroup/memory/memory.max_usage_in_bytes records the maximum of memory usage