### PR TITLE
Add contrib/cloudbuild-{tag,latest,branch}.yaml

### DIFF
--- a/contrib/cloudbuild-branch.yaml
+++ b/contrib/cloudbuild-branch.yaml
@@ -8,7 +8,7 @@ steps:
       ./build.sh \
         -t gcr.io/$PROJECT_ID/$REPO_NAME:$REVISION_ID \
         -t gcr.io/$PROJECT_ID/$REPO_NAME:$BRANCH_NAME \
-        ${TAG_NAME:+-t gcr.io/$PROJECT_ID/$REPO_NAME:$TAG_NAME} \
         .
 images:
-  - 'gcr.io/$PROJECT_ID/$REPO_NAME'
+  - 'gcr.io/$PROJECT_ID/$REPO_NAME:$REVISION_ID'
+  - 'gcr.io/$PROJECT_ID/$REPO_NAME:$BRANCH_NAME'

--- a/contrib/cloudbuild-latest.yaml
+++ b/contrib/cloudbuild-latest.yaml
@@ -1,0 +1,14 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  dir: 'postgres-appliance'
+  entrypoint: 'bash'
+  args:
+    - '-c'
+    - |
+      ./build.sh \
+        -t gcr.io/$PROJECT_ID/$REPO_NAME:$REVISION_ID \
+        -t gcr.io/$PROJECT_ID/$REPO_NAME:latest \
+        .
+images:
+  - 'gcr.io/$PROJECT_ID/$REPO_NAME:$REVISION_ID'
+  - 'gcr.io/$PROJECT_ID/$REPO_NAME:latest'

--- a/contrib/cloudbuild-tag.yaml
+++ b/contrib/cloudbuild-tag.yaml
@@ -1,0 +1,14 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  dir: 'postgres-appliance'
+  entrypoint: 'bash'
+  args:
+    - '-c'
+    - |
+      ./build.sh \
+        -t gcr.io/$PROJECT_ID/$REPO_NAME:$REVISION_ID \
+        -t gcr.io/$PROJECT_ID/$REPO_NAME:$TAG_NAME \
+        .
+images:
+  - 'gcr.io/$PROJECT_ID/$REPO_NAME:$REVISION_ID'
+  - 'gcr.io/$PROJECT_ID/$REPO_NAME:$TAG_NAME'

--- a/contrib/cloudbuild.yaml
+++ b/contrib/cloudbuild.yaml
@@ -10,6 +10,5 @@ steps:
         -t gcr.io/$PROJECT_ID/$REPO_NAME:$BRANCH_NAME \
         ${TAG_NAME:+-t gcr.io/$PROJECT_ID/$REPO_NAME:$TAG_NAME} \
         .
-  ]
 images:
   - 'gcr.io/$PROJECT_ID/$REPO_NAME'

--- a/contrib/cloudbuild.yaml
+++ b/contrib/cloudbuild.yaml
@@ -2,7 +2,7 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   dir: 'postgres-appliance'
   entrypoint: 'bash'
-  args: [
+  args:
     - '-c'
     - |
       ./build.sh \

--- a/contrib/cloudbuild.yaml
+++ b/contrib/cloudbuild.yaml
@@ -1,0 +1,12 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  dir: 'postgres-appliance'
+  entrypoint: './build.sh'
+  args: [
+    '-t', 'gcr.io/$PROJECT_ID/$REPO_NAME:$REVISION_ID',
+    '-t', 'gcr.io/$PROJECT_ID/$REPO_NAME:$TAG_NAME',
+    '-t', 'gcr.io/$PROJECT_ID/$REPO_NAME:$BRANCH_NAME',
+    '.'
+  ]
+images:
+  - 'gcr.io/$PROJECT_ID/$REPO_NAME'

--- a/contrib/cloudbuild.yaml
+++ b/contrib/cloudbuild.yaml
@@ -11,4 +11,6 @@ steps:
         ${TAG_NAME:+-t gcr.io/$PROJECT_ID/$REPO_NAME:$TAG_NAME} \
         .
 images:
-  - 'gcr.io/$PROJECT_ID/$REPO_NAME'
+  - '${TAG_NAME:+gcr.io/$PROJECT_ID/$REPO_NAME:$TAG_NAME}'
+  - 'gcr.io/$PROJECT_ID/$REPO_NAME:$REVISION_ID'
+  - 'gcr.io/$PROJECT_ID/$REPO_NAME:$BRANCH_NAME'

--- a/contrib/cloudbuild.yaml
+++ b/contrib/cloudbuild.yaml
@@ -1,12 +1,15 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
   dir: 'postgres-appliance'
-  entrypoint: './build.sh'
+  entrypoint: 'bash'
   args: [
-    '-t', 'gcr.io/$PROJECT_ID/$REPO_NAME:$REVISION_ID',
-    '-t', 'gcr.io/$PROJECT_ID/$REPO_NAME:$TAG_NAME',
-    '-t', 'gcr.io/$PROJECT_ID/$REPO_NAME:$BRANCH_NAME',
-    '.'
+    - '-c'
+    - |
+      ./build.sh \
+        -t gcr.io/$PROJECT_ID/$REPO_NAME:$REVISION_ID \
+        -t gcr.io/$PROJECT_ID/$REPO_NAME:$BRANCH_NAME \
+        ${TAG_NAME:+-t gcr.io/$PROJECT_ID/$REPO_NAME:$TAG_NAME} \
+        .
   ]
 images:
   - 'gcr.io/$PROJECT_ID/$REPO_NAME'

--- a/contrib/cloudbuild.yaml
+++ b/contrib/cloudbuild.yaml
@@ -11,6 +11,4 @@ steps:
         ${TAG_NAME:+-t gcr.io/$PROJECT_ID/$REPO_NAME:$TAG_NAME} \
         .
 images:
-  - '${TAG_NAME:+gcr.io/$PROJECT_ID/$REPO_NAME:$TAG_NAME}'
-  - 'gcr.io/$PROJECT_ID/$REPO_NAME:$REVISION_ID'
-  - 'gcr.io/$PROJECT_ID/$REPO_NAME:$BRANCH_NAME'
+  - 'gcr.io/$PROJECT_ID/$REPO_NAME'


### PR DESCRIPTION
cloudbuild yaml files, used with Google Cloud Platform's "Build triggers".

The `contrib/cloudbuild-{tag,branch,latest}.yaml` files provide sane defaults and working examples, they are useful in particular since `postgres-appliance/build.sh` must be used since the vanilla:
```yaml
steps: 
  - name: gcr.io/cloud-builders/docker
    args: ["build", "-t", "gcr.io/$PROJECT_ID/$REPO_NAME:latest"]
```
will break due to e.g. missing `scm-source.json`