### PR TITLE
Add git: prefix to url

### DIFF
--- a/postgres-appliance/build.sh
+++ b/postgres-appliance/build.sh
@@ -17,7 +17,7 @@ GITAUTHOR=$(git show -s --format="%aN <%aE>" "$REV")
 
 cat > scm-source.json <<__EOT__
 {
-    "url": "$URL",
+    "url": "git:$URL",
     "revision": "$REV",
     "author": "$GITAUTHOR",
     "status": "$STATUS"


### PR DESCRIPTION
to be compliant with:
http://docs.stups.io/en/latest/user-guide/application-development.html#scm-source-json