### PR TITLE
fix: Can't mix manual and automatic field numbering

### DIFF
--- a/postgres-appliance/configure_spilo.py
+++ b/postgres-appliance/configure_spilo.py
@@ -484,7 +484,7 @@ def main():
     user_config = yaml.load(os.environ.get('SPILO_CONFIGURATION', os.environ.get('PATRONI_CONFIGURATION', ''))) or {}
     if not isinstance(user_config, dict):
         config_var_name = 'SPILO_CONFIGURATION' if 'SPILO_CONFIGURATION' in os.environ else 'PATRONI_CONFIGURATION'
-        raise ValueError('{0} should contain a dict, yet it is a {}'.format(config_var_name, type(user_config)))
+        raise ValueError('{0} should contain a dict, yet it is a {1}'.format(config_var_name, type(user_config)))
 
     config = deep_update(user_config, config)
 


### PR DESCRIPTION
Previously raised 
```pytb
Traceback (most recent call last):
  File "/configure_spilo.py", line 527, in <module>
    main()
  File "/configure_spilo.py", line 487, in main
    raise ValueError('{0} should contain a dict, yet it is a {}'.format(config_var_name, type(user_config)))
ValueError: cannot switch from manual field specification to automatic field numbering
```