### PR TITLE
Remove xlog segments created by pg_receivexlog.

### DIFF
--- a/postgres-appliance/basebackup.sh
+++ b/postgres-appliance/basebackup.sh
@@ -37,7 +37,7 @@ function receivexlog() {
         kill -0 $receivexlog_pid && sleep 1 || exit
     done
 
-    kill $receivexlog_pid && rm -fr ${XLOG_FAST}/*
+    kill $receivexlog_pid && sleep 1 && rm -f ${XLOG_FAST}/*
 }
 
 ATTEMPT=0

--- a/postgres-appliance/basebackup.sh
+++ b/postgres-appliance/basebackup.sh
@@ -37,7 +37,7 @@ function receivexlog() {
         kill -0 $receivexlog_pid && sleep 1 || exit
     done
 
-    kill $receivexlog_pid
+    kill $receivexlog_pid && rm -fr ${XLOG_FAST}/*
 }
 
 ATTEMPT=0

--- a/postgres-appliance/basebackup.sh
+++ b/postgres-appliance/basebackup.sh
@@ -37,7 +37,8 @@ function receivexlog() {
         kill -0 $receivexlog_pid && sleep 1 || exit
     done
 
-    kill $receivexlog_pid && sleep 1 && rm -f ${XLOG_FAST}/*
+    kill $receivexlog_pid && sleep 1
+    rm -f ${XLOG_FAST}/*
 }
 
 ATTEMPT=0


### PR DESCRIPTION
Avoid leaving them around once the replica has started streaming.