### PR TITLE
Configurable usernames for superuser and replication.

### DIFF
--- a/postgres-appliance/configure_spilo.py
+++ b/postgres-appliance/configure_spilo.py
@@ -178,10 +178,10 @@ postgresql:
   {{/USE_WALE}}
   authentication:
     superuser:
-      username: postgres
+      username: {{PGUSER_SUPERUSER}}
       password: '{{PGPASSWORD_SUPERUSER}}'
     replication:
-      username: standby
+      username: {{PGUSER_STANDBY}}
       password: '{{PGPASSWORD_STANDBY}}'
  {{#CALLBACK_SCRIPT}}
   callbacks:
@@ -266,7 +266,9 @@ def get_placeholders(provider):
     placeholders.setdefault('PGROOT', os.path.join(placeholders['PGHOME'], 'pgroot'))
     placeholders.setdefault('WALE_TMPDIR', os.path.abspath(os.path.join(placeholders['PGROOT'], '../tmp')))
     placeholders.setdefault('PGDATA', os.path.join(placeholders['PGROOT'], 'pgdata'))
+    placeholders.setdefault('PGUSER_STANDBY', 'standby')
     placeholders.setdefault('PGPASSWORD_STANDBY', 'standby')
+    placeholders.setdefault('PGUSER_SUPERUSER', 'postgres')
     placeholders.setdefault('PGPASSWORD_SUPERUSER', 'zalando')
     placeholders.setdefault('PGPORT', '5432')
     placeholders.setdefault('SCOPE', 'dummy')


### PR DESCRIPTION
Allow configuring replication- and superuser names for Patroni.