### PR TITLE
Add admin user for to reflect helm chart

### DIFF
--- a/ENVIRONMENT.rst
+++ b/ENVIRONMENT.rst
@@ -14,6 +14,7 @@ Environment Configuration Settings
 - **PGPASSWORD_STANDBY**: a password for the replication user, 'standby' by default.
 - **PGUSER_ADMIN**: username for the default admin user, 'admin' by default.
 - **PGPASSWORD_ADMIN**: a password for the default admin user, 'cola' by default.
+- **USE_ADMIN**: whether to use the admin user or not.
 - **PGUSER_SUPERUSER**: username for the superuser, 'postgres' by default.
 - **PGPASSWORD_SUPERUSER**: a password for the superuser, 'zalando' by default
 - **PGPORT**: port PostgreSQL listens to for client connections, 5432 by default

--- a/ENVIRONMENT.rst
+++ b/ENVIRONMENT.rst
@@ -10,7 +10,11 @@ Environment Configuration Settings
 - **PGROOT**: a directory where we put the pgdata (by default /home/postgres/pgroot). One may adjust it to point to the mount point of the persistent volume, such as EBS.
 - **WALE_TMPDIR**: directory to store WAL-E temporary files. PGROOT/../tmp by default, make sure it has a few GBs of free space.
 - **PGDATA**: location of PostgreSQL data directory, by default PGROOT/pgdata.
+- **PGUSER_STANDBY**: username for the replication user, 'standby' by default.
 - **PGPASSWORD_STANDBY**: a password for the replication user, 'standby' by default.
+- **PGUSER_ADMIN**: username for the default admin user, 'admin' by default.
+- **PGPASSWORD_ADMIN**: a password for the default admin user, 'cola' by default.
+- **PGUSER_SUPERUSER**: username for the superuser, 'postgres' by default.
 - **PGPASSWORD_SUPERUSER**: a password for the superuser, 'zalando' by default
 - **PGPORT**: port PostgreSQL listens to for client connections, 5432 by default
 - **SCOPE**: cluster name, multiple Spilos belonging to the same cluster must have identical scope.

--- a/postgres-appliance/configure_spilo.py
+++ b/postgres-appliance/configure_spilo.py
@@ -148,8 +148,8 @@ bootstrap:
     - hostssl all all 0.0.0.0/0 md5
     - host    all all 0.0.0.0/0 md5
   users:
-    admin:
-      password: '{{PGPASSWORD_ADMIN}}'
+    {{PGUSER_ADMIN}}:
+      password: {{PGPASSWORD_ADMIN}}
       options:
         - createrole
         - createdb
@@ -274,6 +274,7 @@ def get_placeholders(provider):
     placeholders.setdefault('PGDATA', os.path.join(placeholders['PGROOT'], 'pgdata'))
     placeholders.setdefault('PGUSER_STANDBY', 'standby')
     placeholders.setdefault('PGPASSWORD_STANDBY', 'standby')
+    placeholders.setdefault('PGUSER_ADMIN', 'admin')
     placeholders.setdefault('PGPASSWORD_ADMIN', 'cola')
     placeholders.setdefault('PGUSER_SUPERUSER', 'postgres')
     placeholders.setdefault('PGPASSWORD_SUPERUSER', 'zalando')

--- a/postgres-appliance/configure_spilo.py
+++ b/postgres-appliance/configure_spilo.py
@@ -276,7 +276,7 @@ def get_placeholders(provider):
     placeholders.setdefault('PGDATA', os.path.join(placeholders['PGROOT'], 'pgdata'))
     placeholders.setdefault('PGUSER_STANDBY', 'standby')
     placeholders.setdefault('PGPASSWORD_STANDBY', 'standby')
-    placeholders.setdefault('USE_ADMIN', True)
+    placeholders.setdefault('USE_ADMIN', 'PGUSER_ADMIN' in placeholders)
     placeholders.setdefault('PGUSER_ADMIN', 'admin')
     placeholders.setdefault('PGPASSWORD_ADMIN', 'cola')
     placeholders.setdefault('PGUSER_SUPERUSER', 'postgres')

--- a/postgres-appliance/configure_spilo.py
+++ b/postgres-appliance/configure_spilo.py
@@ -153,6 +153,7 @@ bootstrap:
       options:
         - createrole
         - createdb
+        - login
 scope: &scope '{{SCOPE}}'
 restapi:
   listen: 0.0.0.0:{{APIPORT}}

--- a/postgres-appliance/configure_spilo.py
+++ b/postgres-appliance/configure_spilo.py
@@ -154,7 +154,7 @@ bootstrap:
       options:
         - createrole
         - createdb
-  {{/PGUSER_ADMIN}}
+  {{/PGUSER_ADMIN?}}
 scope: &scope '{{SCOPE}}'
 restapi:
   listen: 0.0.0.0:{{APIPORT}}

--- a/postgres-appliance/configure_spilo.py
+++ b/postgres-appliance/configure_spilo.py
@@ -276,7 +276,7 @@ def get_placeholders(provider):
     placeholders.setdefault('PGDATA', os.path.join(placeholders['PGROOT'], 'pgdata'))
     placeholders.setdefault('PGUSER_STANDBY', 'standby')
     placeholders.setdefault('PGPASSWORD_STANDBY', 'standby')
-    placeholders.setdefault('USE_ADMIN', 'PGUSER_ADMIN' in placeholders)
+    placeholders.setdefault('USE_ADMIN', 'PGPASSWORD_ADMIN' in placeholders)
     placeholders.setdefault('PGUSER_ADMIN', 'admin')
     placeholders.setdefault('PGPASSWORD_ADMIN', 'cola')
     placeholders.setdefault('PGUSER_SUPERUSER', 'postgres')

--- a/postgres-appliance/configure_spilo.py
+++ b/postgres-appliance/configure_spilo.py
@@ -147,6 +147,12 @@ bootstrap:
   pg_hba:
     - hostssl all all 0.0.0.0/0 md5
     - host    all all 0.0.0.0/0 md5
+  users:
+    admin:
+      password: '{{PGPASSWORD_ADMIN}}'
+      options:
+        - createrole
+        - createdb
 scope: &scope '{{SCOPE}}'
 restapi:
   listen: 0.0.0.0:{{APIPORT}}
@@ -268,6 +274,7 @@ def get_placeholders(provider):
     placeholders.setdefault('PGDATA', os.path.join(placeholders['PGROOT'], 'pgdata'))
     placeholders.setdefault('PGUSER_STANDBY', 'standby')
     placeholders.setdefault('PGPASSWORD_STANDBY', 'standby')
+    placeholders.setdefault('PGPASSWORD_ADMIN', 'cola')
     placeholders.setdefault('PGUSER_SUPERUSER', 'postgres')
     placeholders.setdefault('PGPASSWORD_SUPERUSER', 'zalando')
     placeholders.setdefault('PGPORT', '5432')

--- a/postgres-appliance/configure_spilo.py
+++ b/postgres-appliance/configure_spilo.py
@@ -147,13 +147,14 @@ bootstrap:
   pg_hba:
     - hostssl all all 0.0.0.0/0 md5
     - host    all all 0.0.0.0/0 md5
+  {{#PGUSER_ADMIN?}}
   users:
     {{PGUSER_ADMIN}}:
       password: {{PGPASSWORD_ADMIN}}
       options:
         - createrole
         - createdb
-        - login
+  {{/PGUSER_ADMIN}}
 scope: &scope '{{SCOPE}}'
 restapi:
   listen: 0.0.0.0:{{APIPORT}}

--- a/postgres-appliance/configure_spilo.py
+++ b/postgres-appliance/configure_spilo.py
@@ -147,14 +147,14 @@ bootstrap:
   pg_hba:
     - hostssl all all 0.0.0.0/0 md5
     - host    all all 0.0.0.0/0 md5
-  {{#PGUSER_ADMIN?}}
+  {{#USE_ADMIN}}
   users:
     {{PGUSER_ADMIN}}:
       password: {{PGPASSWORD_ADMIN}}
       options:
         - createrole
         - createdb
-  {{/PGUSER_ADMIN?}}
+  {{/USE_ADMIN}}
 scope: &scope '{{SCOPE}}'
 restapi:
   listen: 0.0.0.0:{{APIPORT}}
@@ -276,6 +276,7 @@ def get_placeholders(provider):
     placeholders.setdefault('PGDATA', os.path.join(placeholders['PGROOT'], 'pgdata'))
     placeholders.setdefault('PGUSER_STANDBY', 'standby')
     placeholders.setdefault('PGPASSWORD_STANDBY', 'standby')
+    placeholders.setdefault('USE_ADMIN', True)
     placeholders.setdefault('PGUSER_ADMIN', 'admin')
     placeholders.setdefault('PGPASSWORD_ADMIN', 'cola')
     placeholders.setdefault('PGUSER_SUPERUSER', 'postgres')


### PR DESCRIPTION
Trying to figure out why the helm chart value for `PGPASSWORD_ADMIN` wasn't working. It seems like there wasn't a custom user getting creating in the patroni .yaml file for bootstrap.

Feels like this would fix [https://github.com/zalando/spilo/issues/188](https://github.com/zalando/spilo/issues/188). Let me know if this isn't the case either.