### PR TITLE
Request AWS instance data via IP

### DIFF
--- a/postgres-appliance/configure_spilo.py
+++ b/postgres-appliance/configure_spilo.py
@@ -241,7 +241,7 @@ def get_instance_metadata(provider):
         if not USE_KUBERNETES:
             mapping.update({'id': 'id'})
     elif provider == PROVIDER_AWS:
-        url = 'http://instance-data/latest/meta-data'
+        url = 'http://169.254.169.254/latest/meta-data'
         mapping = {'zone': 'placement/availability-zone'}
         if not USE_KUBERNETES:
             mapping.update({'ip': 'local-ipv4', 'id': 'instance-id'})


### PR DESCRIPTION
AWS recommends fetching instance data via IP rather than hostname.

source: https://forums.aws.amazon.com/message.jspa?messageID=536813

Fixes #191 