### PR TITLE
Improve support for namespaces

### DIFF
--- a/postgres-appliance/configure_spilo.py
+++ b/postgres-appliance/configure_spilo.py
@@ -362,7 +362,8 @@ def get_placeholders(provider):
                                 if USE_KUBERNETES and placeholders.get('DCS_ENABLE_KUBERNETES_API') else '')
     # use namespaces to set WAL bucket prefix scope naming the folder namespace-clustername for non-default namespace.
     placeholders.setdefault('WAL_BUCKET_SCOPE_PREFIX',
-                            '{0}-'.format(placeholders['NAMESPACE']) if placeholders['NAMESPACE'] != 'default' else '')
+                            '{0}-'.format(placeholders['NAMESPACE'])\
+                                if placeholders['NAMESPACE'] not in ('', 'default') else '')
     placeholders.setdefault('WAL_BUCKET_SCOPE_SUFFIX', '')
     placeholders.setdefault('WALE_ENV_DIR', os.path.join(placeholders['PGHOME'], 'etc', 'wal-e.d', 'env'))
     placeholders.setdefault('USE_WALE', False)
@@ -470,7 +471,7 @@ def get_dcs_config(config, placeholders):
     else:
         config = {}  # Configuration can also be specified using either SPILO_CONFIGURATION or PATRONI_CONFIGURATION
 
-    if placeholders['NAMESPACE'] != 'default':
+    if placeholders['NAMESPACE'] not in ('default', ''):
         config['namespace'] =  placeholders['NAMESPACE']
 
     return config

--- a/postgres-appliance/configure_spilo.py
+++ b/postgres-appliance/configure_spilo.py
@@ -361,7 +361,7 @@ def get_placeholders(provider):
                             if USE_KUBERNETES and placeholders.get('DCS_ENABLE_KUBERNETES_API') else '')
     # use namespaces to set WAL bucket prefix scope naming the folder namespace-clustername for non-default namespace.
     placeholders.setdefault('WAL_BUCKET_SCOPE_PREFIX', '{0}-'.format(placeholders['NAMESPACE'])
-                            if placeholders['NAMESPACE'] != 'default' else '')
+                            if placeholders['NAMESPACE'] not in ('default', '') else '')
     placeholders.setdefault('WAL_BUCKET_SCOPE_SUFFIX', '')
     placeholders.setdefault('WALE_ENV_DIR', os.path.join(placeholders['PGHOME'], 'etc', 'wal-e.d', 'env'))
     placeholders.setdefault('USE_WALE', False)
@@ -463,7 +463,7 @@ def get_dcs_config(config, placeholders):
     else:
         config = {}  # Configuration can also be specified using either SPILO_CONFIGURATION or PATRONI_CONFIGURATION
 
-    if placeholders['NAMESPACE'] != 'default':
+    if placeholders['NAMESPACE'] not in ('default', ''):
         config['namespace'] = placeholders['NAMESPACE']
 
     return config


### PR DESCRIPTION
if a NAMESPACE parameter is passed to Spilo and is not set to the value 'default', use it as a DCS namespace. In addition, in case of the Kubernetes being set as a DCS, read this parameter from the
POD_NAMESPACE, unless it it set explicitely.

Allow setting the prefix and the suffix for the cluster-specific folder inside the WAL bucket. If NAMESPACE parameter is set to a non-default value, the folder prefix is set to the NAMESPACE value, followed by a dash, unless the folder prefix is set explicitely.