### PR TITLE
Security fix

### DIFF
--- a/postgres-appliance/create_user_functions.sql
+++ b/postgres-appliance/create_user_functions.sql
@@ -51,7 +51,7 @@ CREATE OR REPLACE FUNCTION create_user(username text)
  LANGUAGE plpgsql
 AS $function$
 BEGIN
-    EXECUTE format($$ CREATE USER %I IN ROLE zalandos, admin $$, username);
+    EXECUTE format($$ CREATE USER %I IN ROLE :HUMAN_ROLE, admin $$, username);
     EXECUTE format($$ ALTER ROLE %I SET log_statement TO 'all' $$, username);
 END;
 $function$

--- a/postgres-appliance/create_user_functions.sql
+++ b/postgres-appliance/create_user_functions.sql
@@ -1,4 +1,4 @@
-CREATE SCHEMA user_management;
+CREATE SCHEMA IF NOT EXISTS user_management;
 
 GRANT USAGE ON SCHEMA user_management TO admin;
 
@@ -21,7 +21,8 @@ bricks (b) AS (
     SELECT c FROM chars, generate_series(1, length) ORDER BY random()
 )
 SELECT substr(string_agg(b, ''), 1, length) FROM bricks;
-$$;
+$$
+SET search_path to 'pg_catalog';
 
 CREATE OR REPLACE FUNCTION create_application_user(username text)
  RETURNS text
@@ -35,7 +36,7 @@ BEGIN
     RETURN pw;
 END
 $function$
-SECURITY DEFINER;
+SECURITY DEFINER SET search_path to 'pg_catalog';
 
 REVOKE ALL ON FUNCTION create_application_user(text) FROM public;
 GRANT EXECUTE ON FUNCTION create_application_user(text) TO admin;
@@ -50,11 +51,11 @@ CREATE OR REPLACE FUNCTION create_user(username text)
  LANGUAGE plpgsql
 AS $function$
 BEGIN
-    EXECUTE format($$ CREATE USER %I IN ROLE :HUMAN_ROLE, admin $$, username);
+    EXECUTE format($$ CREATE USER %I IN ROLE zalandos, admin $$, username);
     EXECUTE format($$ ALTER ROLE %I SET log_statement TO 'all' $$, username);
 END;
 $function$
-SECURITY DEFINER;
+SECURITY DEFINER SET search_path to 'pg_catalog';
 
 REVOKE ALL ON FUNCTION create_user(text) FROM public;
 GRANT EXECUTE ON FUNCTION create_user(text) TO admin;
@@ -71,7 +72,7 @@ BEGIN
     EXECUTE format($$ CREATE ROLE %I WITH ADMIN admin $$, rolename);
 END;
 $function$
-SECURITY DEFINER;
+SECURITY DEFINER SET search_path to 'pg_catalog';
 
 REVOKE ALL ON FUNCTION create_role(text) FROM public;
 GRANT EXECUTE ON FUNCTION create_role(text) TO admin;
@@ -94,7 +95,7 @@ BEGIN
     END IF;
 END
 $function$
-SECURITY DEFINER;
+SECURITY DEFINER SET search_path to 'pg_catalog';
 
 REVOKE ALL ON FUNCTION create_application_user_or_change_password(text, text) FROM public;
 GRANT EXECUTE ON FUNCTION create_application_user_or_change_password(text, text) TO admin;
@@ -112,7 +113,7 @@ BEGIN
     EXECUTE format($$ REVOKE admin FROM %I $$, username);
 END
 $function$
-SECURITY DEFINER;
+SECURITY DEFINER SET search_path to 'pg_catalog';
 
 REVOKE ALL ON FUNCTION revoke_admin(text) FROM public;
 GRANT EXECUTE ON FUNCTION revoke_admin(text) TO admin;
@@ -129,7 +130,7 @@ BEGIN
     EXECUTE format($$ DROP ROLE %I $$, username);
 END
 $function$
-SECURITY DEFINER;
+SECURITY DEFINER SET search_path to 'pg_catalog';
 
 REVOKE ALL ON FUNCTION drop_user(text) FROM public;
 GRANT EXECUTE ON FUNCTION drop_user(text) TO admin;
@@ -144,7 +145,7 @@ CREATE OR REPLACE FUNCTION drop_role(username text)
 AS $function$
 SELECT user_management.drop_user(username);
 $function$
-SECURITY DEFINER;
+SECURITY DEFINER SET search_path to 'pg_catalog';
 
 REVOKE ALL ON FUNCTION drop_role(text) FROM public;
 GRANT EXECUTE ON FUNCTION drop_role(text) TO admin;
@@ -159,7 +160,7 @@ CREATE OR REPLACE FUNCTION terminate_backend(pid integer)
 AS $function$
 SELECT pg_terminate_backend(pid);
 $function$
-SECURITY DEFINER;
+SECURITY DEFINER SET search_path to 'pg_catalog';
 
 REVOKE ALL ON FUNCTION terminate_backend(integer) FROM public;
 GRANT EXECUTE ON FUNCTION terminate_backend(integer) TO admin;

--- a/postgres-appliance/post_init.sh
+++ b/postgres-appliance/post_init.sh
@@ -67,13 +67,13 @@ CREATE TABLE postgres_log (
     application_name text,
     CONSTRAINT postgres_log_check CHECK (false) NO INHERIT
 );
-GRANT SELECT ON postgres_log TO ADMIN;"
+GRANT SELECT ON postgres_log TO admin;"
 
 # Sunday could be 0 or 7 depending on the format, we just create both
 for i in $(seq 0 7); do
     echo "CREATE FOREIGN TABLE postgres_log_$i () INHERITS (postgres_log) SERVER pglog
     OPTIONS (filename '../pg_log/postgresql-$i.csv', format 'csv', header 'false');
-GRANT SELECT ON postgres_log_$i TO ADMIN;
+GRANT SELECT ON postgres_log_$i TO admin;
 
 CREATE OR REPLACE VIEW failed_authentication_$i WITH (security_barrier) AS
 SELECT *


### PR DESCRIPTION
Protect user management functions from CVE-2018-1058.

Some of the functions created with security definer are owned by superuser, therefore it is very important to make sure that they are executed with search_path = 'pg_catalog'