### PR TITLE
Adjust path to postgres_backup.sh in launch.sh

### DIFF
--- a/postgres-appliance/launch.sh
+++ b/postgres-appliance/launch.sh
@@ -33,7 +33,7 @@ if [ "$DEMO" = "true" ]; then
 else
     if python3 /scripts/configure_spilo.py all; then
         (
-            su postgres -c "PATH=$PATH /scripts/patroni_wait.sh -t 3600 -- /postgres_backup.sh $WALE_ENV_DIR $PGDATA"
+            su postgres -c "PATH=$PATH /scripts/patroni_wait.sh -t 3600 -- /scripts/postgres_backup.sh $WALE_ENV_DIR $PGDATA"
         ) &
     fi
     exec supervisord --configuration=/etc/supervisor/supervisord.conf --nodaemon


### PR DESCRIPTION
The current value breaks the initial backup with

    /scripts/patroni_wait.sh: line 72: /postgres_backup.sh: No such file or directory
