### PR TITLE
Updated callback to allow user supplied role name via env variables

### DIFF
--- a/postgres-appliance/scripts/callback_role.py
+++ b/postgres-appliance/scripts/callback_role.py
@@ -19,7 +19,7 @@ KUBE_API_URL = 'https://kubernetes.default.svc.cluster.local/api/v1/namespaces'
 logger = logging.getLogger(__name__)
 
 NUM_ATTEMPTS = 10
-LABEL = 'spilo-role'
+LABEL = os.environ.get("KUBERNETES_ROLE_LABEL",'spilo-role')
 
 
 def read_first_line(filename):


### PR DESCRIPTION
Allows user supplied role label (KUBERNETES_ROLE_LABEL) to be consumed even when not setting 'USE_KUBERNETES' flag.  We use etcd to manage the cluster but still wanted the pods to reflect a custom role label.  Ultimately our goal was to let Kubernetes service that gets created use the the custom role label as a selector which could manage the endpoint instead of deploying the headless service. 

eg. This is our service manifest that now doesn't require the endpoint manifest to be deployed but allows kubernetes to create and manage via selector.
```
apiVersion: v1
kind: Service
metadata:
  name: myapp
  labels:
    app: myapp
spec:
  selector:
    myapp-role: "master"
  type: ClusterIP
  ports:
  - name: postgresql
    port: 5432
    targetPort: postgresql
    protocol: TCP
```
Even without the use of the service selector, the custom role label is useful in other scenarios as well. 