### PR TITLE
Fix docker build error

### DIFF
--- a/postgres-appliance/Dockerfile.build
+++ b/postgres-appliance/Dockerfile.build
@@ -226,6 +226,10 @@ RUN export DEBIAN_FRONTEND=noninteractive \
             perl -ne 'print unless /PG_TRY/ .. /PG_CATCH/' pgextwlist.c > pgextwlist.c.f \
             && egrep -v '(PG_END_TRY|EmitWarningsOnPlaceholders)' pgextwlist.c.f > pgextwlist.c; \
         fi \
+        && rm -f debian/pgversions \
+        && for version in ${PGOLDVERSIONS} ${PGVERSION}; do \
+            echo ${version} >> debian/pgversions; \
+        done \
         && pg_buildext updatecontrol \
         && debuild -b -uc -us \
         && cd .. \

--- a/postgres-appliance/Dockerfile.build
+++ b/postgres-appliance/Dockerfile.build
@@ -298,15 +298,15 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
         && if [ -d /usr/share/postgresql/9.5/extension ]; then \
             cd /usr/share/postgresql/9.5/extension \
-        && for f in *.sql *.control; do \
-            for v in 9.3 9.4; do \
-                if [ -f /usr/share/postgresql/$v/extension/$f ] \
-                        && [ ! -L /usr/share/postgresql/$v/extension/$f ] \
-                        && diff $v/extension/$f $f > /dev/null; then \
-                    rm /usr/share/postgresql/$v/extension/$f \
-                    && ln -s /usr/share/postgresql/9.5/extension/$f /usr/share/postgresql/$v/extension/$f; \
-                fi; \
-            done; \
+            && for f in *.sql *.control; do \
+                for v in 9.3 9.4; do \
+                    if [ -f /usr/share/postgresql/$v/extension/$f ] \
+                            && [ ! -L /usr/share/postgresql/$v/extension/$f ] \
+                            && diff $v/extension/$f $f > /dev/null; then \
+                        rm /usr/share/postgresql/$v/extension/$f \
+                        && ln -s /usr/share/postgresql/9.5/extension/$f /usr/share/postgresql/$v/extension/$f; \
+                   fi; \
+                done; \
             done; \
         fi \
 
@@ -331,16 +331,16 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         done \
         && if [ -d /usr/share/postgresql/9.5/contrib/postgis-$POSTGIS_VERSION ]; then \
             cd /usr/share/postgresql/9.5/contrib/postgis-$POSTGIS_VERSION \
-        && for f in *.sql *.pl; do \
-            for v in 9.3 9.4; do \
-                if [ -f /usr/share/postgresql/$v/contrib/postgis-$POSTGIS_VERSION/$f ] \
-                        && [ ! -L /usr/share/postgresql/$v/contrib/postgis-$POSTGIS_VERSION/$f ] \
-                        && diff /usr/share/postgresql/$v/contrib/postgis-$POSTGIS_VERSION/$f $f > /dev/null; then \
-                    rm /usr/share/postgresql/$v/contrib/postgis-$POSTGIS_VERSION/$f \
-                    && ln -s /usr/share/postgresql/9.5/contrib/postgis-$POSTGIS_VERSION/$f \
-                            /usr/share/postgresql/$v/contrib/postgis-$POSTGIS_VERSION/$f; \
-                fi; \
-            done; \
+            && for f in *.sql *.pl; do \
+                for v in 9.3 9.4; do \
+                    if [ -f /usr/share/postgresql/$v/contrib/postgis-$POSTGIS_VERSION/$f ] \
+                            && [ ! -L /usr/share/postgresql/$v/contrib/postgis-$POSTGIS_VERSION/$f ] \
+                            && diff /usr/share/postgresql/$v/contrib/postgis-$POSTGIS_VERSION/$f $f > /dev/null; then \
+                        rm /usr/share/postgresql/$v/contrib/postgis-$POSTGIS_VERSION/$f \
+                        && ln -s /usr/share/postgresql/9.5/contrib/postgis-$POSTGIS_VERSION/$f \
+                                /usr/share/postgresql/$v/contrib/postgis-$POSTGIS_VERSION/$f; \
+                    fi; \
+                done; \
             done; \
         fi \
 

--- a/postgres-appliance/Dockerfile.build
+++ b/postgres-appliance/Dockerfile.build
@@ -73,6 +73,7 @@ ENV PGVERSION="$PGVERSION" \
 
 RUN export DEBIAN_FRONTEND=noninteractive \
     && set -ex \
+    && sed -i 's/^#\s*\(deb.*universe\)$/\1/g' /etc/apt/sources.list \
     && apt-get update \
     && cd /builddeps \
 

--- a/postgres-appliance/Dockerfile.build
+++ b/postgres-appliance/Dockerfile.build
@@ -295,7 +295,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
             done; \
         done \
 
-        && cd /usr/share/postgresql/9.5/extension \
+        && if [ -d /usr/share/postgresql/9.5/extension ]; then \
+            cd /usr/share/postgresql/9.5/extension \
         && for f in *.sql *.control; do \
             for v in 9.3 9.4; do \
                 if [ -f /usr/share/postgresql/$v/extension/$f ] \
@@ -305,7 +306,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
                     && ln -s /usr/share/postgresql/9.5/extension/$f /usr/share/postgresql/$v/extension/$f; \
                 fi; \
             done; \
-        done \
+            done; \
+        fi \
 
         && cd /usr/share/postgresql/$PGVERSION/contrib \
         && for f in *.sql *.html; do \
@@ -326,8 +328,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
                 fi; \
             done; \
         done \
-
-        && cd /usr/share/postgresql/9.5/contrib/postgis-$POSTGIS_VERSION \
+        && if [ -d /usr/share/postgresql/9.5/contrib/postgis-$POSTGIS_VERSION ]; then \
+            cd /usr/share/postgresql/9.5/contrib/postgis-$POSTGIS_VERSION \
         && for f in *.sql *.pl; do \
             for v in 9.3 9.4; do \
                 if [ -f /usr/share/postgresql/$v/contrib/postgis-$POSTGIS_VERSION/$f ] \
@@ -338,7 +340,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
                             /usr/share/postgresql/$v/contrib/postgis-$POSTGIS_VERSION/$f; \
                 fi; \
             done; \
-        done \
+            done; \
+        fi \
 
         && cd /usr/lib/postgresql/$PGVERSION/bin \
         && for u in clusterdb pg_archivecleanup pg_basebackup pg_isready pg_test_fsync pg_test_timing pgbench psql reindexdb vacuumdb vacuumlo *.py; do \


### PR DESCRIPTION
This pr fixes the following build errors:

1. error when using the latest ubuntu:18.04 image
https://github.com/tianon/docker-brew-ubuntu-core/pull/135 , the universe deb-src is not enabled by default
2. error when PGOLDVERSIONS is set to ""
3. rebuild the pg extension package only for the installed version