### PR TITLE
Update timescaledb extension after a failover if it is necessary

### DIFF
--- a/postgres-appliance/Dockerfile.build
+++ b/postgres-appliance/Dockerfile.build
@@ -66,9 +66,9 @@ ENV PGVERSION="$PGVERSION" \
     BG_MON_COMMIT=0cbcfe46804b85ba32021ca688da30341e974d9f \
     DECODERBUFS_COMMIT=c5068d5b42cebcd300520553f639cf1cfdef0b34 \
     SET_USER=REL1_6_1 \
-    PLPGSQL_CHECK=v1.4.0 \
-    PLPROFILER=REL3_2 \
-    TIMESCALEDB=1.1.0 \
+    PLPGSQL_CHECK=v1.4.2 \
+    PLPROFILER_COMMIT=778f81fd6d0086b8839caeec60a2cdaa95d08a17 \
+    TIMESCALEDB=1.1.1 \
     PAM_OAUTH2=v1.0
 
 RUN export DEBIAN_FRONTEND=noninteractive \
@@ -111,9 +111,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         # prepare 3rd sources
         && curl -sL https://github.com/debezium/postgres-decoderbufs/archive/$DECODERBUFS_COMMIT.tar.gz | tar xz \
 
-        && git clone -b $PLPGSQL_CHECK https://github.com/okbob/plpgsql_check.git \
+        && curl -sL https://github.com/pgcentral/plprofiler/archive/$PLPROFILER_COMMIT.tar.gz | tar xz \
 
-        && git clone -b $PLPROFILER https://bitbucket.org/openscg/plprofiler.git \
+        && git clone -b $PLPGSQL_CHECK https://github.com/okbob/plpgsql_check.git \
 
         && git clone -b $TIMESCALEDB https://github.com/timescale/timescaledb.git \
 
@@ -192,7 +192,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
                     && rm -fr pg_rewind-${REWIND_VER} postgresql-${version}*; \
                 fi \
 
-                && EXTRA_EXTENSIONS="plprofiler plantuner" \
+                && EXTRA_EXTENSIONS="plprofiler-$PLPROFILER_COMMIT plantuner" \
                 && if [ "$version" != "9.3" ]; then \
                     EXTRA_EXTENSIONS="$EXTRA_EXTENSIONS plpgsql_check postgres-decoderbufs-$DECODERBUFS_COMMIT"; \
                 fi; \
@@ -375,7 +375,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 # Install patroni, wal-e and wal-g
 ENV PATRONIVERSION=1.5.3
 ENV WALE_VERSION=1.1.0
-ENV WALG_VERSION=v0.2.1
+ENV WALG_VERSION=v0.2.2
 RUN export DEBIAN_FRONTEND=noninteractive \
     && set -ex \
     && BUILD_PACKAGES="python3-pip python3-wheel python3-dev git patchutils binutils" \
@@ -428,6 +428,10 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         && echo 4.0.0.dev0 > supervisor/version.txt; \
     fi \
     && pip3 install "patroni[kubernetes$EXTRAS]==$PATRONIVERSION" \
+
+    # https://github.com/zalando/patroni/pull/896, temporary patch Patroni until the new version is not released
+    && cd /usr/local/lib/python3.6/dist-packages \
+    && curl -sL https://github.com/zalando/patroni/pull/896.diff | patch -p1 \
 
     && for d in /usr/local/lib/python3.6 /usr/lib/python3; do \
         cd $d/dist-packages \

--- a/postgres-appliance/scripts/post_init.sh
+++ b/postgres-appliance/scripts/post_init.sh
@@ -125,10 +125,16 @@ cat _zmon_schema.dump
 
 while IFS= read -r db_name; do
     echo "\c ${db_name}"
+    # In case if timescaledb binary is missing the first query fails with the error
+    # ERROR:  could not access file "$libdir/timescaledb-$OLD_VERSION": No such file or directory
+    TIMESCALEDB_VERSION=$(echo -e "SELECT NULL;\nSELECT extversion FROM pg_extension WHERE extname = 'timescaledb'" | psql -tAX -d ${db_name} 2> /dev/null | tail -n 1)
+    if [ "x$TIMESCALEDB_VERSION" != "x" ] && [ "x$TIMESCALEDB_VERSION" != "x$TIMESCALEDB" ]; then
+        echo "ALTER EXTENSION timescaledb UPDATE;"
+    fi
     sed "s/:HUMAN_ROLE/$1/" create_user_functions.sql
     echo "CREATE EXTENSION IF NOT EXISTS pg_stat_statements SCHEMA public;
 CREATE EXTENSION IF NOT EXISTS set_user SCHEMA public;
 ALTER EXTENSION set_user UPDATE;
 GRANT EXECUTE ON FUNCTION public.set_user(text) TO admin;"
 done < <(psql -d $2 -tAc 'select pg_catalog.quote_ident(datname) from pg_database where datallowconn')
-) | psql -d $2
+) | psql -Xd $2


### PR DESCRIPTION
We don't install old binaries of timescaledb into the image and therefore right after failover timescaledb extension needs to be explicitly updated.

In addition to that, bump versions of wal-g, plpgsql_check and timescaledb and install plprofiler from the new repository.