### PR TITLE
Fix for pod labels never getting set during a role change

### DIFF
--- a/postgres-appliance/scripts/callback_role.py
+++ b/postgres-appliance/scripts/callback_role.py
@@ -18,7 +18,6 @@ KUBE_API_URL = 'https://kubernetes.default.svc.cluster.local/api/v1/namespaces'
 
 logger = logging.getLogger(__name__)
 
-NUM_ATTEMPTS = 10
 LABEL = os.environ.get("KUBERNETES_ROLE_LABEL", 'spilo-role')
 
 
@@ -36,7 +35,7 @@ def read_token():
 
 def api_patch(namespace, kind, name, entity_name, body):
     api_url = '/'.join([KUBE_API_URL, namespace, kind, name])
-    for i in range(NUM_ATTEMPTS):
+    while True:
         try:
             token = read_token()
             if token:
@@ -52,8 +51,6 @@ def api_patch(namespace, kind, name, entity_name, body):
         except requests.exceptions.RequestException as e:
             logger.warning('Exception when executing PATCH on %s: %s', api_url, e)
         time.sleep(1)
-    else:
-        logger.error('Unable to change %s after %s attempts', entity_name, NUM_ATTEMPTS)
 
 
 def change_pod_role_label(namespace, new_role):

--- a/postgres-appliance/scripts/callback_role.py
+++ b/postgres-appliance/scripts/callback_role.py
@@ -19,7 +19,7 @@ KUBE_API_URL = 'https://kubernetes.default.svc.cluster.local/api/v1/namespaces'
 logger = logging.getLogger(__name__)
 
 NUM_ATTEMPTS = 10
-LABEL = 'spilo-role'
+LABEL = os.environ.get("KUBERNETES_ROLE_LABEL",'spilo-role')
 
 
 def read_first_line(filename):


### PR DESCRIPTION
Our environment uses ETCD as our DCS and occasionally we've run into instances where the apiserver is down during the default 10 seconds  (10 attempts) that role labels for cluster members are attempting to be changed. When this happens, we sometimes get multiple 'master' roles set or no 'master' role set. 

It would seem, in any case, there is no reason that the attempt to set the label should end simply because it has hit a certain number of tries without succeeding. Without the labels correctly set, the cluster either has no endpoint to hit (no master) or has two many endpoints to hit (multiple masters) that causes intermittent failures for clients connecting. 

Unless there is sometime I'm missing, I think the attempt to set a label should continue until successful. 