### PR TITLE
Control AWS instance profile behaviour from the envdir

### DIFF
--- a/postgres-appliance/bootstrap/clone_with_wale.py
+++ b/postgres-appliance/bootstrap/clone_with_wale.py
@@ -40,7 +40,7 @@ def read_configuration():
 
 
 def build_wale_command(command, datadir=None, backup=None):
-    cmd = (['wal-g'] if os.getenv('USE_WALG_BACKUP') == 'true' else ['wal-e', '--aws-instance-profile']) + [command]
+    cmd = ['wal-g' if os.getenv('USE_WALG_BACKUP') == 'true' else 'wal-e'] + [command]
     if command == 'backup-fetch':
         if datadir is None or backup is None:
             raise Exception("backup-fetch requires datadir and backup arguments")

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -446,7 +446,7 @@ def get_placeholders(provider):
 
     placeholders.setdefault('postgresql', {})
     placeholders['postgresql'].setdefault('parameters', {})
-    placeholders['WALE_BINARY'] = 'wal-g' if use_walg_backup else 'wal-e --aws-instance-profile'
+    placeholders['WALE_BINARY'] = 'wal-g' if use_walg_backup else 'wal-e'
     placeholders['postgresql']['parameters']['archive_command'] = \
         'envdir "{WALE_ENV_DIR}" {WALE_BINARY} wal-push "%p"'.format(**placeholders) \
         if placeholders['USE_WALE'] else '/bin/true'
@@ -593,6 +593,9 @@ def write_wale_environment(placeholders, provider, prefix, overwrite):
         wale['WALE_S3_PREFIX'] = 's3://{WAL_S3_BUCKET}{BUCKET_PATH}'.format(**wale)
         wale.update(WALE_S3_ENDPOINT=wale_endpoint, AWS_ENDPOINT=aws_endpoint, AWS_REGION=aws_region)
         write_envdir_names = s3_names
+        if not ('AWS_SECRET_ACCESS_KEY' in wale and 'AWS_ACCESS_KEY_ID' in wale):
+            wale['AWS_INSTANCE_PROFILE'] = 'true'
+            write_envdir_names.append('AWS_INSTANCE_PROFILE')
     elif wale.get('WAL_GCS_BUCKET'):
         wale['WALE_GS_PREFIX'] = 'gs://{WAL_GCS_BUCKET}{BUCKET_PATH}'.format(**wale)
         write_envdir_names = gs_names

--- a/postgres-appliance/scripts/postgres_backup.sh
+++ b/postgres-appliance/scripts/postgres_backup.sh
@@ -30,7 +30,7 @@ if [[ "$USE_WALG_BACKUP" == "true" ]]; then
     [[ -z $WALG_BACKUP_COMPRESSION_METHOD ]] || export WALG_COMPRESSION_METHOD=$WALG_BACKUP_COMPRESSION_METHOD
     export PGHOST=/var/run/postgresql
 else
-    readonly WAL_E="wal-e --aws-instance-profile"
+    readonly WAL_E="wal-e"
 
     # Ensure we don't have more workes than CPU's
     POOL_SIZE=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1)

--- a/postgres-appliance/scripts/restore_command.sh
+++ b/postgres-appliance/scripts/restore_command.sh
@@ -23,5 +23,5 @@ if [[ -z $WALE_S3_PREFIX ]]; then  # non AWS environment?
         exec wal-e wal-fetch -p $POOL_SIZE "${wal_filename}" "${wal_destination}"
     fi
 else
-    exec bash /scripts/wal-e-wal-fetch.sh --aws-instance-profile wal-fetch -p $POOL_SIZE "${wal_filename}" "${wal_destination}"
+    exec bash /scripts/wal-e-wal-fetch.sh wal-fetch -p $POOL_SIZE "${wal_filename}" "${wal_destination}"
 fi

--- a/postgres-appliance/scripts/wal-e-wal-fetch.sh
+++ b/postgres-appliance/scripts/wal-e-wal-fetch.sh
@@ -5,8 +5,6 @@ date
 
 prefetch=8
 
-AWS_INSTANCE_PROFILE=0
-
 function load_aws_instance_profile() {
     local CREDENTIALS_URL=http://169.254.169.254/latest/meta-data/iam/security-credentials/
     local INSTANCE_PROFILE=$(curl -s $CREDENTIALS_URL)
@@ -34,7 +32,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --aws-instance-profile )
-            AWS_INSTANCE_PROFILE=1
+            AWS_INSTANCE_PROFILE=true
             ;;
         wal-fetch )
             ;;
@@ -51,7 +49,7 @@ done
 
 [[ ${#PARAMS[@]} == 2 ]] || usage
 
-[[ $AWS_INSTANCE_PROFILE == 1 ]] && load_aws_instance_profile
+[[ "$AWS_INSTANCE_PROFILE" == "true" ]] && load_aws_instance_profile
 
 if [[ -z $AWS_SECRET_ACCESS_KEY || -z $AWS_ACCESS_KEY_ID || -z $WALE_S3_PREFIX ]]; then
     echo bad environment
@@ -74,7 +72,7 @@ if [[ -z $AWS_REGION ]]; then
     if [[ ! -z $WALE_S3_ENDPOINT && $WALE_S3_ENDPOINT =~ ^([a-z\+]{2,10}://)?(s3-([^\.]+)[^:\/?]+) ]]; then
         S3_HOST=${BASH_REMATCH[2]}
         AWS_REGION=${BASH_REMATCH[3]}
-    elif [[ $AWS_INSTANCE_PROFILE == 1 ]]; then
+    elif [[ "$AWS_INSTANCE_PROFILE" == "true" ]]; then
         load_region_from_aws_instance_profile
     fi
 fi

--- a/postgres-appliance/scripts/wale_restore.sh
+++ b/postgres-appliance/scripts/wale_restore.sh
@@ -35,7 +35,7 @@ if [[ "$USE_WALG_RESTORE" == "true" ]]; then
     readonly WAL_E="wal-g"
     readonly backup_start_field_num=3
 else
-    readonly WAL_E="wal-e --aws-instance-profile"
+    readonly WAL_E="wal-e"
     readonly backup_start_field_num=4
 fi
 


### PR DESCRIPTION
configure_spilo.py will write 'true' into AWS_INSTANCE_PROFILE file in the envdir when S3 is requested and AWS_SECRET_ACCESS_KEY/AWS_ACCESS_KEY_ID are not specified.

Hope it will resolve https://github.com/zalando-incubator/postgres-operator/issues/488