### PR TITLE
Added logic to remove circular links

### DIFF
--- a/postgres-appliance/Dockerfile.build
+++ b/postgres-appliance/Dockerfile.build
@@ -279,6 +279,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         && if [ -d /usr/share/postgresql/9.5/contrib/postgis-$POSTGIS_VERSION ]; then \
             cd /usr/share/postgresql/9.5/contrib/postgis-$POSTGIS_VERSION \
             && for f in *.sql *.pl; do \
+                 if [ -L /usr/share/postgresql/9.5/contrib/postgis-$POSTGIS_VERSION/$f ]; then \
+                   continue; \
+                 fi; \
                 for v in 9.4 9.6 10; do \
                     if [ -f /usr/share/postgresql/$v/contrib/postgis-$POSTGIS_VERSION/$f ] \
                             && [ ! -L /usr/share/postgresql/$v/contrib/postgis-$POSTGIS_VERSION/$f ] \
@@ -328,6 +331,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         && if [ -d /usr/share/postgresql/9.5/extension ]; then \
             cd /usr/share/postgresql/9.5/extension \
             && for f in *.sql *.control; do \
+                  if [ -L /usr/share/postgresql/9.5/extension/$f ]; then \
+                     continue; \
+                  fi; \
                 for v in 9.3 9.4 9.6 10; do \
                     if [ -f /usr/share/postgresql/$v/extension/$f ] \
                             && [ ! -L /usr/share/postgresql/$v/extension/$f ] \

--- a/postgres-appliance/Dockerfile.build
+++ b/postgres-appliance/Dockerfile.build
@@ -282,7 +282,10 @@ RUN export DEBIAN_FRONTEND=noninteractive \
                  if [ -L /usr/share/postgresql/9.5/contrib/postgis-$POSTGIS_VERSION/$f ]; then \
                    continue; \
                  fi; \
-                for v in 9.4 9.6 10; do \
+                 for v in $PGOLDVERSIONS; do \
+                     if [ $v == 9.5 ]; then \
+                       continue; \
+                     fi; \
                     if [ -f /usr/share/postgresql/$v/contrib/postgis-$POSTGIS_VERSION/$f ] \
                             && [ ! -L /usr/share/postgresql/$v/contrib/postgis-$POSTGIS_VERSION/$f ] \
                             && diff /usr/share/postgresql/$v/contrib/postgis-$POSTGIS_VERSION/$f $f > /dev/null; then \
@@ -334,7 +337,10 @@ RUN export DEBIAN_FRONTEND=noninteractive \
                   if [ -L /usr/share/postgresql/9.5/extension/$f ]; then \
                      continue; \
                   fi; \
-                for v in 9.3 9.4 9.6 10; do \
+                  for v in $PGOLDVERSIONS; do \
+                      if [ $v == 9.5 ]; then \
+                        continue; \
+                      fi; \
                     if [ -f /usr/share/postgresql/$v/extension/$f ] \
                             && [ ! -L /usr/share/postgresql/$v/extension/$f ] \
                             && diff /usr/share/postgresql/$v/extension/$f $f > /dev/null; then \

--- a/postgres-appliance/Dockerfile.build
+++ b/postgres-appliance/Dockerfile.build
@@ -279,14 +279,11 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         && if [ -d /usr/share/postgresql/9.5/contrib/postgis-$POSTGIS_VERSION ]; then \
             cd /usr/share/postgresql/9.5/contrib/postgis-$POSTGIS_VERSION \
             && for f in *.sql *.pl; do \
-                 if [ -L /usr/share/postgresql/9.5/contrib/postgis-$POSTGIS_VERSION/$f ]; then \
+                 if [ -L $f ]; then \
                    continue; \
-                 fi; \
-                 for v in $PGOLDVERSIONS; do \
-                     if [ $v == 9.5 ]; then \
-                       continue; \
-                     fi; \
-                    if [ -f /usr/share/postgresql/$v/contrib/postgis-$POSTGIS_VERSION/$f ] \
+                 fi \
+                 && for v in $PGOLDVERSIONS; do \
+                    if [ $v != 9.5 ] && [ -f /usr/share/postgresql/$v/contrib/postgis-$POSTGIS_VERSION/$f ] \
                             && [ ! -L /usr/share/postgresql/$v/contrib/postgis-$POSTGIS_VERSION/$f ] \
                             && diff /usr/share/postgresql/$v/contrib/postgis-$POSTGIS_VERSION/$f $f > /dev/null; then \
                         rm /usr/share/postgresql/$v/contrib/postgis-$POSTGIS_VERSION/$f \
@@ -334,14 +331,11 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         && if [ -d /usr/share/postgresql/9.5/extension ]; then \
             cd /usr/share/postgresql/9.5/extension \
             && for f in *.sql *.control; do \
-                  if [ -L /usr/share/postgresql/9.5/extension/$f ]; then \
+                  if [ -L $f ]; then \
                      continue; \
-                  fi; \
-                  for v in $PGOLDVERSIONS; do \
-                      if [ $v == 9.5 ]; then \
-                        continue; \
-                      fi; \
-                    if [ -f /usr/share/postgresql/$v/extension/$f ] \
+                  fi \
+                  && for v in $PGOLDVERSIONS; do \
+                    if [ $v != 9.5 ] && [ -f /usr/share/postgresql/$v/extension/$f ] \
                             && [ ! -L /usr/share/postgresql/$v/extension/$f ] \
                             && diff /usr/share/postgresql/$v/extension/$f $f > /dev/null; then \
                         rm /usr/share/postgresql/$v/extension/$f \

--- a/postgres-appliance/Dockerfile.build
+++ b/postgres-appliance/Dockerfile.build
@@ -279,10 +279,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         && if [ -d /usr/share/postgresql/9.5/contrib/postgis-$POSTGIS_VERSION ]; then \
             cd /usr/share/postgresql/9.5/contrib/postgis-$POSTGIS_VERSION \
             && for f in *.sql *.pl; do \
-                 if [ -L $f ]; then \
-                   continue; \
-                 fi \
-                 && for v in $PGOLDVERSIONS; do \
+                if [ -L $f ]; then continue; fi \
+                && for v in $PGOLDVERSIONS; do \
                     if [ $v != 9.5 ] && [ -f /usr/share/postgresql/$v/contrib/postgis-$POSTGIS_VERSION/$f ] \
                             && [ ! -L /usr/share/postgresql/$v/contrib/postgis-$POSTGIS_VERSION/$f ] \
                             && diff /usr/share/postgresql/$v/contrib/postgis-$POSTGIS_VERSION/$f $f > /dev/null; then \
@@ -331,10 +329,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         && if [ -d /usr/share/postgresql/9.5/extension ]; then \
             cd /usr/share/postgresql/9.5/extension \
             && for f in *.sql *.control; do \
-                  if [ -L $f ]; then \
-                     continue; \
-                  fi \
-                  && for v in $PGOLDVERSIONS; do \
+                if [ -L $f ]; then continue; fi \
+                && for v in $PGOLDVERSIONS; do \
                     if [ $v != 9.5 ] && [ -f /usr/share/postgresql/$v/extension/$f ] \
                             && [ ! -L /usr/share/postgresql/$v/extension/$f ] \
                             && diff /usr/share/postgresql/$v/extension/$f $f > /dev/null; then \

--- a/postgres-appliance/scripts/callback_role.py
+++ b/postgres-appliance/scripts/callback_role.py
@@ -18,7 +18,6 @@ KUBE_API_URL = 'https://kubernetes.default.svc.cluster.local/api/v1/namespaces'
 
 logger = logging.getLogger(__name__)
 
-NUM_ATTEMPTS = 10
 LABEL = os.environ.get("KUBERNETES_ROLE_LABEL", 'spilo-role')
 
 
@@ -36,7 +35,7 @@ def read_token():
 
 def api_patch(namespace, kind, name, entity_name, body):
     api_url = '/'.join([KUBE_API_URL, namespace, kind, name])
-    for i in range(NUM_ATTEMPTS):
+    while True:
         try:
             token = read_token()
             if token:
@@ -52,8 +51,6 @@ def api_patch(namespace, kind, name, entity_name, body):
         except requests.exceptions.RequestException as e:
             logger.warning('Exception when executing PATCH on %s: %s', api_url, e)
         time.sleep(1)
-    else:
-        logger.error('Unable to change %s after %s attempts', entity_name, NUM_ATTEMPTS)
 
 
 def change_pod_role_label(namespace, new_role):

--- a/postgres-appliance/scripts/callback_role.py
+++ b/postgres-appliance/scripts/callback_role.py
@@ -19,7 +19,7 @@ KUBE_API_URL = 'https://kubernetes.default.svc.cluster.local/api/v1/namespaces'
 logger = logging.getLogger(__name__)
 
 NUM_ATTEMPTS = 10
-LABEL = 'spilo-role'
+LABEL = os.environ.get("KUBERNETES_ROLE_LABEL",'spilo-role')
 
 
 def read_first_line(filename):


### PR DESCRIPTION
Attempted to do a build for postgresql version 10 and realized it was creating circular links.

This ultimately was causing the database to become unable to bootstrap.

I don't totally understand the reasoning behind the sections of the code that create links back to the postgresql 9.5 version but without the changes I've added it effectively created circular links and wiped out the actual files. 

When I ran the build to produce the squashed image these were the version settings in the Dockerfile.build file:
```
ARG PGOLDVERSIONS="9.3 9.4 9.5 9.6"
ARG PGVERSION="10"
```

Example of one file (topology.sql) that ends up with a circular link  
```
# pwd
/usr/share/postgresql/9.5/contrib/postgis-2.5
# ls -l /usr/share/postgresql/10/contrib/postgis-2.5/topology.sql
lrwxrwxrwx. 1 root root 58 Feb 17 18:58 /usr/share/postgresql/10/contrib/postgis-2.5/topology.sql -> /usr/share/postgresql/9.5/contrib/postgis-2.5/topology.sql
# ls -l /usr/share/postgresql/9.5/contrib/postgis-2.5/topology.sql
lrwxrwxrwx. 1 root root 57 Feb 17 18:58 /usr/share/postgresql/9.5/contrib/postgis-2.5/topology.sql -> /usr/share/postgresql/10/contrib/postgis-2.5/topology.sql
```

Their might be a better way to solve this issue like removing the version PGVERSION from the list of versions it's cycling through when creating the link but it's probably a good check to not use links as a source for a ln your creating.

Anyway, feel free to share your thoughts on this. I'm really curious about the reasoning behind the 9.5 links.
