### PR TITLE
Get rid of patroni_aws

### DIFF
--- a/postgres-appliance/scripts/callback_aws.py
+++ b/postgres-appliance/scripts/callback_aws.py
@@ -51,10 +51,13 @@ def get_instance(ec2, instance_id):
 
 def main():
     logging.basicConfig(format='%(asctime)s %(levelname)s: %(message)s', level=logging.INFO)
-    if len(sys.argv) != 5 or sys.argv[2] not in ('on_start', 'on_stop', 'on_role_change'):
-        sys.exit("Usage: {0} eip_allocation_id action role name".format(sys.argv[0]))
 
-    action, role, cluster = sys.argv[2:5]
+    # EIP_ALLOCATION is optional argument
+    argc = len(sys.argv)
+    if argc not in (4, 5) or sys.argv[argc - 3] not in ('on_start', 'on_stop', 'on_role_change'):
+        sys.exit("Usage: {0} [eip_allocation_id] action role name".format(sys.argv[0]))
+
+    action, role, cluster = sys.argv[argc - 3:argc]
 
     metadata = get_instance_metadata()
 
@@ -62,10 +65,10 @@ def main():
 
     ec2 = boto.ec2.connect_to_region(metadata['region'])
 
-    instance = get_instance(ec2, instance_id)
-
-    if role == 'master' and action in ('on_start', 'on_role_change'):
+    if role == 'master' and argc == 5 and action in ('on_start', 'on_role_change'):
         associate_address(ec2, sys.argv[1], instance_id)
+
+    instance = get_instance(ec2, instance_id)
 
     tags = {'Role': role}
     tag_resource(ec2, instance_id, tags)

--- a/postgres-appliance/scripts/callback_aws.py
+++ b/postgres-appliance/scripts/callback_aws.py
@@ -65,7 +65,7 @@ def main():
 
     ec2 = boto.ec2.connect_to_region(metadata['region'])
 
-    if role == 'master' and argc == 5 and action in ('on_start', 'on_role_change'):
+    if argc == 5 and role in ('master', 'standby_leader') and action in ('on_start', 'on_role_change'):
         associate_address(ec2, sys.argv[1], instance_id)
 
     instance = get_instance(ec2, instance_id)

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -422,13 +422,11 @@ def get_placeholders(provider):
             logging.warning("Clone method is set to basebackup, but no 'CLONE_SCOPE' "
                             "or 'CLONE_HOST' or 'CLONE_USER' or 'CLONE_PASSWORD' specified")
 
-    if provider == PROVIDER_AWS:
-        if not USE_KUBERNETES:  # AWS specific callback to tag the instances with roles
-            if placeholders.get('EIP_ALLOCATION'):
-                placeholders['CALLBACK_SCRIPT'] = 'python3 /scripts/callback_aws.py {0}'. \
-                                                     format(placeholders['EIP_ALLOCATION'])
-            else:
-                placeholders['CALLBACK_SCRIPT'] = 'patroni_aws'
+    if provider == PROVIDER_AWS and not USE_KUBERNETES:
+        # AWS specific callback to tag the instances with roles
+        placeholders['CALLBACK_SCRIPT'] = 'python3 /scripts/callback_aws.py'
+        if placeholders.get('EIP_ALLOCATION'):
+            placeholders['CALLBACK_SCRIPT'] += ' ' + placeholders['EIP_ALLOCATION']
 
     set_walg_placeholders(placeholders)
 


### PR DESCRIPTION
It was used only on AWS for clusters without epi and setting wrong names on EBS volumes.