### PR TITLE
Fix S3_HOST detection for non-AWS S3

### DIFF
--- a/postgres-appliance/scripts/wal-e-wal-fetch.sh
+++ b/postgres-appliance/scripts/wal-e-wal-fetch.sh
@@ -68,10 +68,13 @@ else
     exit 1
 fi
 
+if [[ ! -z $WALE_S3_ENDPOINT && $WALE_S3_ENDPOINT =~ ^([a-z\+]{2,10}://)?([^:\/?]+) ]]; then
+    S3_HOST=${BASH_REMATCH[2]}
+fi
+
 if [[ -z $AWS_REGION ]]; then
-    if [[ ! -z $WALE_S3_ENDPOINT && $WALE_S3_ENDPOINT =~ ^([a-z\+]{2,10}://)?(s3-([^\.]+)[^:\/?]+) ]]; then
-        S3_HOST=${BASH_REMATCH[2]}
-        AWS_REGION=${BASH_REMATCH[3]}
+    if [[ ! -z $WALE_S3_ENDPOINT && $WALE_S3_ENDPOINT =~ ^([a-z\+]{2,10}://)?s3-([^\.]+) ]]; then
+        AWS_REGION=${BASH_REMATCH[2]}
     elif [[ "$AWS_INSTANCE_PROFILE" == "true" ]]; then
         load_region_from_aws_instance_profile
     fi


### PR DESCRIPTION
When using non-AWS S3 provider, `S3_HOST` is constructed incorrectly in WAL restore script. Moreover, it is impossible to override `S3_HOST` with container environment, so there's no way for WAL restore to work with non-AWS S3 storage. See https://github.com/zalando/postgres-operator/issues/550 for details.

The PR fixes `S3_HOST` detection for non-AWS S3 endpoints. Of course, it still works for AWS S3.