### PR TITLE
add ability to specify multiple etcd hosts that are supported by patroni

### DIFF
--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -557,6 +557,8 @@ def get_dcs_config(config, placeholders):
                                 'port': placeholders['EXHIBITOR_PORT']}}
     elif 'ETCD_HOST' in placeholders:
         config = {'etcd': {'host': placeholders['ETCD_HOST']}}
+    elif 'ETCD_HOSTS' in placeholders:
+        config = {'etcd': {'hosts': placeholders['ETCD_HOST']}}
     elif 'ETCD_DISCOVERY_DOMAIN' in placeholders:
         config = {'etcd': {'discovery_srv': placeholders['ETCD_DISCOVERY_DOMAIN']}}
     else:
@@ -828,6 +830,7 @@ def main():
     if (provider == PROVIDER_LOCAL and
             not USE_KUBERNETES and
             'ETCD_HOST' not in placeholders and
+            'ETCD_HOSTS' not in placeholders and
             'ETCD_DISCOVERY_DOMAIN' not in placeholders):
         write_etcd_configuration(placeholders)
 


### PR DESCRIPTION
Related to this part of the patroni setup
https://github.com/zalando/patroni/blob/master/patroni/dcs/etcd.py#L369
```
        elif 'hosts' in config:
            hosts = config.pop('hosts')
            default_port = config.pop('port', 2379)
            protocol = config.get('protocol', 'http')

            if isinstance(hosts, six.string_types):
                hosts = hosts.split(',')

            config['hosts'] = []
            for value in hosts:
                if isinstance(value, six.string_types):
                    config['hosts'].append(uri(protocol, *split_host_port(value, default_port)))
        elif 'host' in config:
            host, port = split_host_port(config['host'], 2379)
            config['host'] = host
            if 'port' not in config:
                config['port'] = int(port)
```