### PR TITLE
[configure_spilo] add ALLOW_NOSSL environment variable

### DIFF
--- a/ENVIRONMENT.rst
+++ b/ENVIRONMENT.rst
@@ -18,6 +18,7 @@ Environment Configuration Settings
 - **USE_ADMIN**: whether to use the admin user or not.
 - **PGUSER_SUPERUSER**: username for the superuser, 'postgres' by default.
 - **PGPASSWORD_SUPERUSER**: a password for the superuser, 'zalando' by default
+- **ALLOW_NOSSL**: set to allow clients to connect without SSL enabled.
 - **PGPORT**: port PostgreSQL listens to for client connections, 5432 by default
 - **PGVERSION**: Specifies the version of postgreSQL to reference in the bin_dir variable (/usr/lib/postgresql/PGVERSION/bin) if postgresql.bin_dir wasn't set in SPILO_CONFIGURATION
 - **SCOPE**: cluster name, multiple Spilos belonging to the same cluster must have identical scope.

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -251,15 +251,15 @@ postgresql:
     {{/PAM_OAUTH2}}
     - host    all             all                ::1/128            md5
     - hostssl replication     {{PGUSER_STANDBY}} all                md5
-    {{#ALLOW_NOSSL}}
-    - host    all             all                all                md5
-    {{/ALLOW_NOSSL}}
     {{^ALLOW_NOSSL}}
     - hostnossl all           all                all                reject
     {{/ALLOW_NOSSL}}
     {{#PAM_OAUTH2}}
     - hostssl all             +{{HUMAN_ROLE}}    all                pam
     {{/PAM_OAUTH2}}
+    {{#ALLOW_NOSSL}}
+    - host    all             all                all                md5
+    {{/ALLOW_NOSSL}}
     - hostssl all             all                all                md5
 
   {{#USE_WALE}}

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -251,14 +251,16 @@ postgresql:
     {{/PAM_OAUTH2}}
     - host    all             all                ::1/128            md5
     - hostssl replication     {{PGUSER_STANDBY}} all                md5
+    {{#ALLOW_NOSSL}}
+    - host    all             all                all                md5
+    {{/ALLOW_NOSSL}}
+    {{^ALLOW_NOSSL}}
     - hostnossl all           all                all                reject
+    {{/ALLOW_NOSSL}}
     {{#PAM_OAUTH2}}
     - hostssl all             +{{HUMAN_ROLE}}    all                pam
     {{/PAM_OAUTH2}}
     - hostssl all             all                all                md5
-    {{#ALLOW_NOSSL}}
-    - host    all             all                all                md5
-    {{/ALLOW_NOSSL}}
 
   {{#USE_WALE}}
   recovery_conf:

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -256,6 +256,9 @@ postgresql:
     - hostssl all             +{{HUMAN_ROLE}}    all                pam
     {{/PAM_OAUTH2}}
     - hostssl all             all                all                md5
+    {{#ALLOW_NOSSL}}
+    - host    all             all                all                md5
+    {{/ALLOW_NOSSL}}
 
   {{#USE_WALE}}
   recovery_conf:
@@ -409,6 +412,7 @@ def get_placeholders(provider):
     placeholders.setdefault('PGPASSWORD_ADMIN', 'cola')
     placeholders.setdefault('PGUSER_SUPERUSER', 'postgres')
     placeholders.setdefault('PGPASSWORD_SUPERUSER', 'zalando')
+    placeholders.setdefault('ALLOW_NOSSL', '')
     placeholders.setdefault('PGPORT', '5432')
     placeholders.setdefault('SCOPE', 'dummy')
     placeholders.setdefault('SSL_CERTIFICATE_FILE', os.path.join(placeholders['PGHOME'], 'server.crt'))

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -260,7 +260,9 @@ postgresql:
     {{#ALLOW_NOSSL}}
     - host    all             all                all                md5
     {{/ALLOW_NOSSL}}
+    {{^ALLOW_NOSSL}}
     - hostssl all             all                all                md5
+    {{/ALLOW_NOSSL}}
 
   {{#USE_WALE}}
   recovery_conf:


### PR DESCRIPTION
some apps (such as Geoserver) don't support connecting to the database over SSL. This adds an environment variable `ALLOW_NOSSL` in order to allow these applications to still connect to the database.

fixes #367