### PR TITLE
Run dumb-init only after decompressing image

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -515,4 +515,4 @@ RUN sed -i "s|/var/lib/postgresql.*|$PGHOME:/bin/bash|" /etc/passwd \
 COPY scripts bootstrap /scripts/
 COPY scm-source.json launch.sh /
 
-CMD ["/usr/bin/dumb-init", "-c", "--rewrite", "1:0", "--", "/bin/sh", "/launch.sh"]
+CMD ["/bin/sh", "/launch.sh", "init"]

--- a/postgres-appliance/launch.sh
+++ b/postgres-appliance/launch.sh
@@ -11,6 +11,10 @@ if [ -f /a.tar.xz ]; then
     fi
 fi
 
+if [ "x$1" = "xinit" ]; then
+    exec /usr/bin/dumb-init -c --rewrite 1:0 -- /bin/sh /launch.sh
+fi
+
 mkdir -p "$PGLOG"
 
 ## Ensure all logfiles exist, most appliances will have


### PR DESCRIPTION
If the launch.sh is called with init parameter it will re-execute itself via dumb-init