### PR TITLE
Patroni needs more environment variables

### DIFF
--- a/postgres-appliance/runit/patroni/run
+++ b/postgres-appliance/runit/patroni/run
@@ -11,5 +11,10 @@ if ! $CHPST true 2> /dev/null; then
     CHPST=""
 fi
 
+# Only small subset of environment variables is allowed. We don't want accidentally disclose sensitive information
+for E in $(env | grep -vE '^(KUBERNETES_(SERVICE|PORT|ROLE)[_=]|((POD_(IP|NAMESPACE))|HOSTNAME|HOME|PATH|LC_ALL|TIMESCALEDB)=)' | sed 's/=.*//g'); do
+    unset $E
+done
+
 exec 2>&1
-exec $CHRT $CHPST env -i HOME=/home/postgres PATH=$PATH patroni /home/postgres/postgres.yml
+exec $CHRT $CHPST patroni /home/postgres/postgres.yml


### PR DESCRIPTION
For example KUBERNETES_SERVICE_* are necessary for communication with K8s API, POD_NAME and POD_NAMESPACE and needed for callback scripts, and so on.

We can't just pass all of them due to the https://github.com/zalando/patroni/commit/d770c910fdeb4420f4fd33c7f39f3f487a5cdf2b