### PR TITLE
handle TLS certificate rotation

### DIFF
--- a/ENVIRONMENT.rst
+++ b/ENVIRONMENT.rst
@@ -23,6 +23,7 @@ Environment Configuration Settings
 - **PGVERSION**: Specifies the version of postgreSQL to reference in the bin_dir variable (/usr/lib/postgresql/PGVERSION/bin) if postgresql.bin_dir wasn't set in SPILO_CONFIGURATION
 - **SCOPE**: cluster name, multiple Spilos belonging to the same cluster must have identical scope.
 - **SSL_CA_FILE**: path to the SSL CA certificate file inside the container (by default: '')
+- **SSL_CRL_FILE**: path to the SSL Certificate Revocation List file inside the container (by default: '')
 - **SSL_CERTIFICATE_FILE**: path to the SSL certificate file inside the container (by default PGHOME/server.crt), Spilo will generate one if not present.
 - **SSL_PRIVATE_KEY_FILE**: path to the SSL private key within the container (by default PGHOME/server.key), Spilo will generate one if not present
 - **WALE_BACKUP_THRESHOLD_MEGABYTES**: maximum size of the WAL segments accumulated after the base backup to consider WAL-E restore instead of pg_basebackup.

--- a/ENVIRONMENT.rst
+++ b/ENVIRONMENT.rst
@@ -22,6 +22,7 @@ Environment Configuration Settings
 - **PGPORT**: port PostgreSQL listens to for client connections, 5432 by default
 - **PGVERSION**: Specifies the version of postgreSQL to reference in the bin_dir variable (/usr/lib/postgresql/PGVERSION/bin) if postgresql.bin_dir wasn't set in SPILO_CONFIGURATION
 - **SCOPE**: cluster name, multiple Spilos belonging to the same cluster must have identical scope.
+- **SSL_CA_FILE**: path to the SSL CA certificate file inside the container (by default: '')
 - **SSL_CERTIFICATE_FILE**: path to the SSL certificate file inside the container (by default PGHOME/server.crt), Spilo will generate one if not present.
 - **SSL_PRIVATE_KEY_FILE**: path to the SSL private key within the container (by default PGHOME/server.key), Spilo will generate one if not present
 - **WALE_BACKUP_THRESHOLD_MEGABYTES**: maximum size of the WAL segments accumulated after the base backup to consider WAL-E restore instead of pg_basebackup.

--- a/ENVIRONMENT.rst
+++ b/ENVIRONMENT.rst
@@ -26,6 +26,7 @@ Environment Configuration Settings
 - **SSL_CRL_FILE**: path to the SSL Certificate Revocation List file inside the container (by default: '')
 - **SSL_CERTIFICATE_FILE**: path to the SSL certificate file inside the container (by default PGHOME/server.crt), Spilo will generate one if not present.
 - **SSL_PRIVATE_KEY_FILE**: path to the SSL private key within the container (by default PGHOME/server.key), Spilo will generate one if not present
+- **SSL_TEST_RELOAD**: whenever to test for certificate rotation and reloading (by default True if SSL_PRIVATE_KEY_FILE has been set)
 - **WALE_BACKUP_THRESHOLD_MEGABYTES**: maximum size of the WAL segments accumulated after the base backup to consider WAL-E restore instead of pg_basebackup.
 - **WALE_BACKUP_THRESHOLD_PERCENTAGE**: maximum ratio (in percents) of the accumulated WAL files to the base backup to consider WAL-E restore instead of pg_basebackup.
 - **WALE_ENV_DIR**: directory where to store WAL-E environment variables

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -244,6 +244,7 @@ postgresql:
     log_truncate_on_rotation: 'on'
     ssl: 'on'
     ssl_ca_file: {{SSL_CA_FILE}}
+    ssl_crl_file: {{SSL_CRL_FILE}}
     ssl_cert_file: {{SSL_CERTIFICATE_FILE}}
     ssl_key_file: {{SSL_PRIVATE_KEY_FILE}}
     shared_preload_libraries: 'bg_mon,pg_stat_statements,pgextwlist,pg_auth_mon,set_user'
@@ -455,6 +456,7 @@ def get_placeholders(provider):
     placeholders.setdefault('PGPORT', '5432')
     placeholders.setdefault('SCOPE', 'dummy')
     placeholders.setdefault('SSL_CA_FILE', '')
+    placeholders.setdefault('SSL_CRL_FILE', '')
     placeholders.setdefault('SSL_CERTIFICATE_FILE', os.path.join(placeholders['PGHOME'], 'server.crt'))
     placeholders.setdefault('SSL_PRIVATE_KEY_FILE', os.path.join(placeholders['PGHOME'], 'server.key'))
     placeholders.setdefault('WALE_BACKUP_THRESHOLD_MEGABYTES', 102400)

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -243,6 +243,7 @@ postgresql:
     log_rotation_age: '1d'
     log_truncate_on_rotation: 'on'
     ssl: 'on'
+    ssl_ca_file: {{SSL_CA_FILE}}
     ssl_cert_file: {{SSL_CERTIFICATE_FILE}}
     ssl_key_file: {{SSL_PRIVATE_KEY_FILE}}
     shared_preload_libraries: 'bg_mon,pg_stat_statements,pgextwlist,pg_auth_mon,set_user'
@@ -453,6 +454,7 @@ def get_placeholders(provider):
     placeholders.setdefault('BGMON_LISTEN_IP', '0.0.0.0')
     placeholders.setdefault('PGPORT', '5432')
     placeholders.setdefault('SCOPE', 'dummy')
+    placeholders.setdefault('SSL_CA_FILE', '')
     placeholders.setdefault('SSL_CERTIFICATE_FILE', os.path.join(placeholders['PGHOME'], 'server.crt'))
     placeholders.setdefault('SSL_PRIVATE_KEY_FILE', os.path.join(placeholders['PGHOME'], 'server.key'))
     placeholders.setdefault('WALE_BACKUP_THRESHOLD_MEGABYTES', 102400)

--- a/postgres-appliance/scripts/test_reload_ssl.sh
+++ b/postgres-appliance/scripts/test_reload_ssl.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# This script is being called every TEST_INTERVAL_MINUTES to check if the
+# spilo or postgres configuration need to be reloaded.
+#
+# Usage: test_reload_ssl.sh <TEST_INTERVAL_MINUTES>
+set -euo pipefail
+
+# How often this script is being called
+test_interval_min=$1
+test_interval_sec=$((test_interval_min * 60))
+
+## Functions ##
+
+log() {
+    echo "$*" >&2
+}
+
+has_changed() {
+    local env=$1
+    local path=${!1:-}
+    if [[ -z "$path" ]]; then
+        log "env=$env: environment is not set"
+        return 1
+    fi
+    if [[ ! -e "$path" ]]; then
+        log "env=$env path=$path: does not exist"
+        return 1
+    fi
+    local mtime now elapsed_sec
+    mtime=$(stat -c '%Y' "$path")
+    now=$(date +%s)
+    elapsed_sec=$(( now - 1 - mtime ))
+    if [[ $elapsed_sec -gt $test_interval_sec ]]; then
+        log "env=$env path=$path elapsec_sec=$elapsed_sec: no changes detected"
+        return 1
+    fi
+    log "env=$env path=$path elapsec_sec=$elapsed_sec: found changes"
+    return 0
+}
+
+## Main ##
+
+if
+    has_changed SSL_CA_FILE || \
+    has_changed SSL_CRL_FILE || \
+    has_changed SSL_CERTIFICATE_FILE || \
+    has_changed SSL_PRIVATE_KEY_FILE
+then
+    log "Reloading due to detected changes"
+    pg_ctl reload
+fi


### PR DESCRIPTION
When the SSL_PRIVATE_KEY_FILE is not a self-generated certificate, the file can change over time. But right now postgresql doesn't know about it and won't load the new certificate automatically.

This PR introduces a bit of a polling approach to solve that problem. Every 5 minutes it will have a look if the certificate has changed within that interval and trigger a `pg_ctl reload` if yes. There are possibly smarter approaches like listen on inotify events but this has the advantage that no additional process needs to be running and running a bash script every 5 minutes is quite lite-weight.
