### PR TITLE
add possibility to configure ETCD via url or proxy url 

### DIFF
--- a/ENVIRONMENT.rst
+++ b/ENVIRONMENT.rst
@@ -4,6 +4,11 @@ Environment Configuration Settings
 - **ETCD_HOST**: the DNS A record pointing to Etcd hosts.
 - **ETCD_HOSTS**: list of Etcd hosts in format host1:port1,host2:port2,etc.
 - **ETCD_DISCOVERY_DOMAIN**: the DNS SRV record pointing to Etcd hosts.
+- **ETCD_URL**: url for Etcd host in format http(s)://host1:port
+- **ETCD_PROXY**: url for Etcd Proxy format http(s)://host1:port
+- **ETCD_CACERT**: Etcd CA certificate. If present it will enable validation.
+- **ETCD_CERT**: Etcd client certificate.
+- **ETCD_KEY**: Etcd client certificate key. Can be empty if the key is part of certificate.
 - **PGHOME**: filesystem path where to put PostgreSQL home directory (/home/postgres by default)
 - **APIPORT**: TCP port to Patroni API connections (8008 by default)
 - **BACKUP_SCHEDULE**: cron schedule for doing backups via WAL-E (if WAL-E is enabled, '00 01 * * *' by default)

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -614,8 +614,19 @@ def get_dcs_config(config, placeholders):
         config = {'etcd': {'hosts': placeholders['ETCD_HOSTS']}}
     elif 'ETCD_DISCOVERY_DOMAIN' in placeholders:
         config = {'etcd': {'discovery_srv': placeholders['ETCD_DISCOVERY_DOMAIN']}}
+    elif 'ETCD_URL' in placeholders:
+        config = {'etcd': {'url': placeholders['ETCD_URL']}}
+    elif 'ETCD_PROXY' in placeholders:
+        config = {'etcd': {'proxy': placeholders['ETCD_PROXY']}}
     else:
         config = {}  # Configuration can also be specified using either SPILO_CONFIGURATION or PATRONI_CONFIGURATION
+
+    if 'CACERT' in placeholders :
+        config['etcd'].update({'cacert': placeholders['CACERT']})
+    if 'KEY' in placeholders :
+        config['etcd'].update({'key': placeholders['KEY']})
+    if 'CERT' in placeholders :
+        config['etcd'].update({'cert': placeholders['CERT']})
 
     if placeholders['NAMESPACE'] not in ('default', ''):
         config['namespace'] = placeholders['NAMESPACE']
@@ -868,6 +879,8 @@ def main():
             not USE_KUBERNETES and
             'ETCD_HOST' not in placeholders and
             'ETCD_HOSTS' not in placeholders and
+            'ETCD_URL' not in placeholders and
+            'ETCD_PROXY' not in placeholders and
             'ETCD_DISCOVERY_DOMAIN' not in placeholders):
         write_etcd_configuration(placeholders)
 

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -621,12 +621,12 @@ def get_dcs_config(config, placeholders):
     else:
         config = {}  # Configuration can also be specified using either SPILO_CONFIGURATION or PATRONI_CONFIGURATION
 
-    if 'CACERT' in placeholders :
-        config['etcd'].update({'cacert': placeholders['CACERT']})
-    if 'KEY' in placeholders :
-        config['etcd'].update({'key': placeholders['KEY']})
-    if 'CERT' in placeholders :
-        config['etcd'].update({'cert': placeholders['CERT']})
+    if 'ETCD_CACERT' in placeholders :
+        config['etcd'].update({'cacert': placeholders['ETCD_CACERT']})
+    if 'ETCD_KEY' in placeholders :
+        config['etcd'].update({'key': placeholders['ETCD_KEY']})
+    if 'ETCD_CERT' in placeholders :
+        config['etcd'].update({'cert': placeholders['ETCD_CERT']})
 
     if placeholders['NAMESPACE'] not in ('default', ''):
         config['namespace'] = placeholders['NAMESPACE']


### PR DESCRIPTION
This adds a possibility to configure ETCD via URL or proxy as well as permits specifying SSL certificates for ETCD connection. 

Fixes #381 