### PR TITLE
Timescaledb 1.5.1

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -1,5 +1,6 @@
 ARG PGVERSION=12
-ARG TIMESCALEDB=1.4.2
+ARG TIMESCALEDB=1.5.1
+ARG TIMESCALEDB_LEGACY=$TIMESCALEDB
 ARG DEMO=false
 
 FROM ubuntu:18.04 as builder
@@ -55,6 +56,7 @@ ADD set_user.patch /builddeps/
 
 ARG PGVERSION
 ARG TIMESCALEDB
+ARG TIMESCALEDB_LEGACY
 ARG DEMO
 ARG PGOLDVERSIONS="9.3 9.4 9.5 9.6 10 11"
 ARG WITH_PERL=false
@@ -116,7 +118,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && curl -sL https://github.com/RafiaSabih/pg_auth_mon/archive/$PG_AUTH_MON_COMMIT.tar.gz | tar xz \
     && git clone -b $SET_USER https://github.com/pgaudit/set_user.git \
     && patch -d set_user -p1 < set_user.patch \
-    && git clone -b $TIMESCALEDB https://github.com/timescale/timescaledb.git \
+    && git clone -b $TIMESCALEDB_LEGACY https://github.com/timescale/timescaledb.git \
 \
     && apt-get install -y libevent-2.1 libevent-pthreads-2.1 python3.6 python3-psycopg2 \
 \
@@ -166,8 +168,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
             # Install 3rd party stuff
             && if [ "$version" = "9.6" ] || [ "$version" = "10" ] || [ "$version" = "11" ] ; then \
                 cd timescaledb \
+                && if [ "$version" != "9.6" ]; then git checkout $TIMESCALEDB; fi \
                 && rm -fr build \
-                && ./bootstrap -DAPACHE_ONLY=1 -DSEND_TELEMETRY_DEFAULT=NO \
+                && ./bootstrap -DAPACHE_ONLY=1 -DSEND_TELEMETRY_DEFAULT=NO -DREGRESS_CHECKS=OFF \
                 && make -C build install \
                 && strip /usr/lib/postgresql/$version/lib/timescaledb*.so \
                 && cd ..; \
@@ -482,14 +485,16 @@ LABEL maintainer="Alexander Kukushkin <alexander.kukushkin@zalando.de>"
 
 ARG PGVERSION
 ARG TIMESCALEDB
+ARG TIMESCALEDB_LEGACY
 ARG DEMO
 
 EXPOSE 5432 8008 8080
 
 ENV LC_ALL=en_US.utf-8 \
-    PATH=/usr/lib/postgresql/$PGVERSION/bin:$PATH \
+    PATH=$PATH:/usr/lib/postgresql/$PGVERSION/bin \
     PGHOME=/home/postgres \
     TIMESCALEDB=$TIMESCALEDB \
+    TIMESCALEDB_LEGACY=$TIMESCALEDB_LEGACY \
     DEMO=$DEMO
 
 ENV WALE_ENV_DIR=$PGHOME/etc/wal-e.d/env \

--- a/postgres-appliance/scripts/post_init.sh
+++ b/postgres-appliance/scripts/post_init.sh
@@ -133,14 +133,17 @@ while IFS= read -r db_name; do
     echo "\c ${db_name}"
     # In case if timescaledb binary is missing the first query fails with the error
     # ERROR:  could not access file "$libdir/timescaledb-$OLD_VERSION": No such file or directory
-    TIMESCALEDB_VERSION=$(echo -e "SELECT NULL;\nSELECT extversion FROM pg_catalog.pg_extension WHERE extname = 'timescaledb'" | psql -tAX -d ${db_name} 2> /dev/null | tail -n 1)
+    TIMESCALEDB_VERSION=$(echo -e "SELECT NULL;\nSELECT extversion FROM pg_catalog.pg_extension WHERE extname = 'timescaledb'" | psql -tAX -d "${db_name}" 2> /dev/null | tail -n 1)
     if [ "x$TIMESCALEDB_VERSION" != "x" ] && [ "x$TIMESCALEDB_VERSION" != "x$TIMESCALEDB" ]; then
-        echo "ALTER EXTENSION timescaledb UPDATE;"
+        LEGACY=$(psql -d "$2" -XtAc "SELECT pg_catalog.current_setting('server_version_num')::int/10000 < 10")
+        if [ "x$LEGACY" != "xt" ] || [ "x$TIMESCALEDB_VERSION" != "x$TIMESCALEDB_LEGACY" ]; then
+            echo "ALTER EXTENSION timescaledb UPDATE;"
+        fi
     fi
-    POSTGISDB_VERSION=$(echo -e "SELECT extversion != postgis_lib_version() FROM pg_catalog.pg_extension WHERE extname = 'postgis'" | psql -tAX -d ${db_name} 2> /dev/null | tail -n 1)
-    if [ "x$POSTGISDB_VERSION" = "xtrue" ]; then
+    UPGRADE_POSTGIS=$(echo -e "SELECT extversion != public.postgis_lib_version() FROM pg_catalog.pg_extension WHERE extname = 'postgis'" | psql -tAX -d "${db_name}" 2> /dev/null | tail -n 1)
+    if [ "x$UPGRADE_POSTGIS" = "xt" ]; then
         echo "ALTER EXTENSION postgis UPDATE;"
-        echo "SELECT postgis_extensions_upgrade();"
+        echo "SELECT public.postgis_extensions_upgrade();"
     fi
     sed "s/:HUMAN_ROLE/$1/" create_user_functions.sql
     echo "CREATE EXTENSION IF NOT EXISTS pg_stat_statements SCHEMA public;

--- a/postgres-appliance/scripts/post_init.sh
+++ b/postgres-appliance/scripts/post_init.sh
@@ -129,16 +129,17 @@ done
 
 cat _zmon_schema.dump
 
+PGVER=$(psql -d "$2" -XtAc "SELECT pg_catalog.current_setting('server_version_num')::int/10000")
+if [ $PGVER -ge 12 ]; then RESET_ARGS="oid, oid, bigint"; fi
+
 while IFS= read -r db_name; do
     echo "\c ${db_name}"
     # In case if timescaledb binary is missing the first query fails with the error
     # ERROR:  could not access file "$libdir/timescaledb-$OLD_VERSION": No such file or directory
     TIMESCALEDB_VERSION=$(echo -e "SELECT NULL;\nSELECT extversion FROM pg_catalog.pg_extension WHERE extname = 'timescaledb'" | psql -tAX -d "${db_name}" 2> /dev/null | tail -n 1)
-    if [ "x$TIMESCALEDB_VERSION" != "x" ] && [ "x$TIMESCALEDB_VERSION" != "x$TIMESCALEDB" ]; then
-        LEGACY=$(psql -d "$2" -XtAc "SELECT pg_catalog.current_setting('server_version_num')::int/10000 < 10")
-        if [ "x$LEGACY" != "xt" ] || [ "x$TIMESCALEDB_VERSION" != "x$TIMESCALEDB_LEGACY" ]; then
-            echo "ALTER EXTENSION timescaledb UPDATE;"
-        fi
+    if [ "x$TIMESCALEDB_VERSION" != "x" ] && [ "x$TIMESCALEDB_VERSION" != "x$TIMESCALEDB" ] \
+            && [ $PGVER -gt 9 -o "x$TIMESCALEDB_VERSION" != "x$TIMESCALEDB_LEGACY" ]; then
+        echo "ALTER EXTENSION timescaledb UPDATE;"
     fi
     UPGRADE_POSTGIS=$(echo -e "SELECT extversion != public.postgis_lib_version() FROM pg_catalog.pg_extension WHERE extname = 'postgis'" | psql -tAX -d "${db_name}" 2> /dev/null | tail -n 1)
     if [ "x$UPGRADE_POSTGIS" = "xt" ]; then
@@ -151,7 +152,7 @@ CREATE EXTENSION IF NOT EXISTS pg_stat_kcache SCHEMA public;
 CREATE EXTENSION IF NOT EXISTS set_user SCHEMA public;
 ALTER EXTENSION set_user UPDATE;
 GRANT EXECUTE ON FUNCTION public.set_user(text) TO admin;
-GRANT EXECUTE ON FUNCTION public.pg_stat_statements_reset() TO admin;"
+GRANT EXECUTE ON FUNCTION public.pg_stat_statements_reset($RESET_ARGS) TO admin;"
     cat metric_helpers.sql
 done < <(psql -d "$2" -tAc 'select pg_catalog.quote_ident(datname) from pg_catalog.pg_database where datallowconn')
 ) | psql -Xd "$2"


### PR DESCRIPTION
Timescaledb is planning to deprecate support for postgres 9.6 in upcoming releases. In order to prepare for it we introduce the new variable, `TIMESCALEDB_LEGACY`. Now it has the same value as
`TIMESCALEDB`, but in future it will stick to the last release supporting 9.6.

In addition to that fix the postgis upgrade and reorder PATH. It is better when the psql is found as /usr/bin/psql, because it does some magic with LD_PRELOAD=ibreadline.so in order to provide better usability.