### PR TITLE
Limit the number of unexpected restarts of Patroni

### DIFF
--- a/postgres-appliance/runit/patroni/finish
+++ b/postgres-appliance/runit/patroni/finish
@@ -1,0 +1,38 @@
+#!/bin/sh -e
+
+STATUS_FILE=supervise/restarts
+MAX_RESTARTS=5
+BACKOFF=30
+
+echo "$PWD: finished with code=$1 signal=$2"
+
+# unexpected exit code
+if [ "$1" != "0" ] && [ "$1" != "2" ]; then
+    # don't count restarts if the service was killed by OOM
+    if [ "$2" = "9" ]; then
+        exit 0
+    fi
+
+    if [ -f $STATUS_FILE ]; then
+        RESTARTS=$(cat $STATUS_FILE)
+    fi
+
+    # no status file or garbage in it
+    if ! [ "$RESTARTS" -eq "$RESTARTS" ] 2> /dev/null
+    then
+        RESTARTS=1
+    fi
+
+    echo $((RESTARTS + 1)) > $STATUS_FILE
+
+    if [ "$RESTARTS" -lt "$MAX_RESTARTS" ]; then
+        SLEEPTIME=$((RESTARTS * BACKOFF))
+        echo "$PWD: sleeping $SLEEPTIME seconds"
+        exec sleep $SLEEPTIME
+    fi
+    echo "$PWD: exceeded maximum number of restarts $MAX_RESTARTS"
+fi
+
+echo "stopping $PWD"
+sv stop .
+rm -f $STATUS_FILE

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -68,9 +68,9 @@ def link_runit_service(name):
     if not os.path.exists(service_dir):
         os.makedirs(service_dir)
         for f in ('run', 'finish'):
+            src_file = os.path.join('/etc/runit/runsvdir/default', name, f)
             dst_file = os.path.join(service_dir, f)
-            if not os.path.exists(dst_file):
-                src_file = os.path.join('/etc/runit/runsvdir/default', name, f)
+            if os.path.exists(src_file) and not os.path.exists(dst_file):
                 os.symlink(src_file, dst_file)
 
 

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -64,13 +64,14 @@ def parse_args():
 
 
 def link_runit_service(name):
-    service_dir = '/run/service/' + name
+    service_dir = os.path.join('/run/service', name)
     if not os.path.exists(service_dir):
         os.makedirs(service_dir)
-        run_file = service_dir + '/run'
-        if not os.path.exists(run_file):
-            source_file = '/etc/runit/runsvdir/default/{0}/run'.format(name)
-            os.symlink(source_file, run_file)
+        for f in ('run', 'finish'):
+            dst_file = os.path.join(service_dir, f)
+            if not os.path.exists(dst_file):
+                src_file = os.path.join('/etc/runit/runsvdir/default', name, f)
+                os.symlink(src_file, dst_file)
 
 
 def write_certificates(environment, overwrite):


### PR DESCRIPTION
Usually that happens if the custom_bootstrap is failing.

The maximum number of restarts is 5. Between every attempt the backoff is applied. Backoff time is calculated as ATTEMPT*30.

Cases when Patroni is killed with -9 or by OOM are excluded (number of restarts is not limited and backoff is not applied).