### PR TITLE
Make it possible to run with read-only root fs

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -492,13 +492,14 @@ EXPOSE 5432 8008 8080
 ENV LC_ALL=en_US.utf-8 \
     PATH=$PATH:/usr/lib/postgresql/$PGVERSION/bin \
     PGHOME=/home/postgres \
+    RW_DIR=/run \
     TIMESCALEDB=$TIMESCALEDB \
     TIMESCALEDB_LEGACY=$TIMESCALEDB_LEGACY \
     DEMO=$DEMO
 
-ENV WALE_ENV_DIR=$PGHOME/etc/wal-e.d/env \
-    PGROOT=$PGHOME/pgdata/pgroot \
-    LOG_ENV_DIR=$PGHOME/etc/log.d/env
+ENV WALE_ENV_DIR=$RW_DIR/etc/wal-e.d/env \
+    LOG_ENV_DIR=$RW_DIR/etc/log.d/env \
+    PGROOT=$PGHOME/pgdata/pgroot
 
 ENV PGDATA=$PGROOT/data \
     PGLOG=$PGROOT/pg_log
@@ -510,13 +511,27 @@ COPY runit /etc/service/
 COPY pgq_ticker.ini $PGHOME/
 
 RUN sed -i "s|/var/lib/postgresql.*|$PGHOME:/bin/bash|" /etc/passwd \
-        && chown -R postgres:postgres $PGHOME /run \
-        && ln -snf /run/service /etc/service \
+        && chown -R postgres:postgres $PGHOME $RW_DIR \
+        && rm -fr /var/spool/cron /var/tmp \
+        && ln -s $RW_DIR/cron /var/spool/cron \
+        && ln -s $RW_DIR/tmp /var/tmp \
+        && ln -snf $RW_DIR/service /etc/service \
+        && ln -s $RW_DIR/pam.d-postgresql /etc/pam.d/postgresql \
+        && ln -s $RW_DIR/postgres.yml $PGHOME/postgres.yml \
+        && ln -s $RW_DIR/.bash_history /root/.bash_history \
+        && ln -s $RW_DIR/postgresql/.bash_history $PGHOME/.bash_history \
+        && ln -s $RW_DIR/postgresql/.psql_history $PGHOME/.psql_history \
+        && for d in $PGHOME /root; do \
+            d=$d/.config/patroni \
+            && mkdir -p $d \
+            && ln -s $PGHOME/postgres.yml $d/patronictl.yaml; \
+        done \
         && sed -i 's/set compatible/set nocompatible/' /etc/vim/vimrc.tiny \
         && echo "PATH=\"$PATH\"" > /etc/environment \
         && for e in TERM=linux LC_ALL=C.UTF-8 LANG=C.UTF-8 EDITOR=editor "PAGER='pspg -bX --no-mouse'"; \
             do echo "export $e" >> /etc/bash.bashrc; \
         done \
+        && ln -s /etc/skel/.bashrc $PGHOME/.bashrc \
         && echo "source /etc/motd" >> /root/.bashrc
 
 COPY scripts bootstrap /scripts/

--- a/postgres-appliance/launch.sh
+++ b/postgres-appliance/launch.sh
@@ -15,7 +15,7 @@ if [ "x$1" = "xinit" ]; then
     exec /usr/bin/dumb-init -c --rewrite 1:0 -- /bin/sh /launch.sh
 fi
 
-mkdir -p "$PGLOG"
+mkdir -p "$PGLOG" "$RW_DIR/postgresql" "$RW_DIR/tmp"
 
 ## Ensure all logfiles exist, most appliances will have
 ## a foreign data wrapper pointing to these files
@@ -24,7 +24,8 @@ for i in $(seq 0 7); do
         touch "${PGLOG}/postgresql-$i.csv"
     fi
 done
-chown -R postgres:postgres "$PGROOT"
+chown -R postgres:postgres "$PGROOT" "$RW_DIR/postgresql"
+chmod 01777 "$RW_DIR/tmp"
 
 if [ "$DEMO" = "true" ]; then
     python3 /scripts/configure_spilo.py patroni patronictl pgqd certificate pam-oauth2

--- a/postgres-appliance/launch.sh
+++ b/postgres-appliance/launch.sh
@@ -28,7 +28,7 @@ chown -R postgres:postgres "$PGROOT" "$RW_DIR/postgresql"
 chmod 01777 "$RW_DIR/tmp"
 
 if [ "$DEMO" = "true" ]; then
-    python3 /scripts/configure_spilo.py patroni patronictl pgqd certificate pam-oauth2
+    python3 /scripts/configure_spilo.py patroni pgqd certificate pam-oauth2
 elif python3 /scripts/configure_spilo.py all; then
     su postgres -c "PATH=$PATH /scripts/patroni_wait.sh -t 3600 -- envdir $WALE_ENV_DIR /scripts/postgres_backup.sh $PGDATA $BACKUP_NUM_TO_RETAIN" &
 fi

--- a/postgres-appliance/motd
+++ b/postgres-appliance/motd
@@ -1,4 +1,4 @@
-cat <<__EOT__
+echo "
  ____        _ _
 / ___| _ __ (_) | ___
 \___ \| '_ \| | |/ _ \\
@@ -14,7 +14,6 @@ sv stop cron
 sv restart patroni
 
 Current status: (sv status /etc/service/*)
-
-__EOT__
+"
 
 [ -d /etc/service ] && sv status /etc/service/*

--- a/postgres-appliance/runit/etcd/run
+++ b/postgres-appliance/runit/etcd/run
@@ -1,4 +1,4 @@
 #!/bin/sh -e
 
 exec 2>&1
-exec env -i /bin/etcd --data-dir /tmp/etcd.data
+exec env -i /bin/etcd --data-dir /run/etcd.data

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -442,7 +442,7 @@ def get_placeholders(provider):
     placeholders.setdefault('PGHOME', os.path.expanduser('~'))
     placeholders.setdefault('APIPORT', '8008')
     placeholders.setdefault('BACKUP_SCHEDULE', '0 1 * * *')
-    placeholders.setdefault('BACKUP_NUM_TO_RETAIN', 2)
+    placeholders.setdefault('BACKUP_NUM_TO_RETAIN', 5)
     placeholders.setdefault('CRONTAB', '[]')
     placeholders.setdefault('PGROOT', os.path.join(placeholders['PGHOME'], 'pgroot'))
     placeholders.setdefault('WALE_TMPDIR', os.path.abspath(os.path.join(placeholders['PGROOT'], '../tmp')))

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -42,7 +42,7 @@ AUTO_ENABLE_WALG_RESTORE = ('WAL_S3_BUCKET', 'WALE_S3_PREFIX', 'WALG_S3_PREFIX')
 
 
 def parse_args():
-    sections = ['all', 'patroni', 'patronictl', 'pgqd', 'certificate', 'wal-e', 'crontab',
+    sections = ['all', 'patroni', 'pgqd', 'certificate', 'wal-e', 'crontab',
                 'pam-oauth2', 'pgbouncer', 'bootstrap', 'standby-cluster', 'log', 'renice']
     argp = argparse.ArgumentParser(description='Configures Spilo',
                                    epilog="Choose from the following sections:\n\t{}".format('\n\t'.join(sections)),
@@ -63,8 +63,8 @@ def parse_args():
     return args
 
 
-def link_runit_service(name):
-    service_dir = '/run/service/' + name
+def link_runit_service(placeholders, name):
+    service_dir = os.path.join(placeholders['RW_DIR'], 'service', name)
     if not os.path.exists(service_dir):
         os.makedirs(service_dir)
         run_file = service_dir + '/run'
@@ -227,6 +227,7 @@ restapi:
   listen: ':{{APIPORT}}'
   connect_address: {{instance_data.ip}}:{{APIPORT}}
 postgresql:
+  pgpass: /run/postgresql/pgpass
   use_unix_socket: true
   name: '{{instance_data.id}}'
   listen: '*:{{PGPORT}}'
@@ -398,7 +399,7 @@ def set_extended_wale_placeholders(placeholders, prefix):
 
     scope = placeholders.get(prefix + 'SCOPE')
     dirname = 'env-' + prefix[:-1].lower() + ('-' + scope if scope else '')
-    placeholders[prefix + 'WALE_ENV_DIR'] = os.path.join(placeholders['PGHOME'], 'etc', 'wal-e.d', dirname)
+    placeholders[prefix + 'WALE_ENV_DIR'] = os.path.join(placeholders['RW_DIR'], 'etc', 'wal-e.d', dirname)
     placeholders[prefix + 'WITH_WALE'] = True
     return name
 
@@ -442,7 +443,7 @@ def get_placeholders(provider):
     placeholders.setdefault('PGHOME', os.path.expanduser('~'))
     placeholders.setdefault('APIPORT', '8008')
     placeholders.setdefault('BACKUP_SCHEDULE', '0 1 * * *')
-    placeholders.setdefault('BACKUP_NUM_TO_RETAIN', 5)
+    placeholders.setdefault('BACKUP_NUM_TO_RETAIN', '5')
     placeholders.setdefault('CRONTAB', '[]')
     placeholders.setdefault('PGROOT', os.path.join(placeholders['PGHOME'], 'pgroot'))
     placeholders.setdefault('WALE_TMPDIR', os.path.abspath(os.path.join(placeholders['PGROOT'], '../tmp')))
@@ -459,11 +460,12 @@ def get_placeholders(provider):
     placeholders.setdefault('BGMON_LISTEN_IP', '0.0.0.0')
     placeholders.setdefault('PGPORT', '5432')
     placeholders.setdefault('SCOPE', 'dummy')
+    placeholders.setdefault('RW_DIR', '/run')
     placeholders.setdefault('SSL_TEST_RELOAD', 'SSL_PRIVATE_KEY_FILE' in os.environ)
     placeholders.setdefault('SSL_CA_FILE', '')
     placeholders.setdefault('SSL_CRL_FILE', '')
-    placeholders.setdefault('SSL_CERTIFICATE_FILE', os.path.join(placeholders['PGHOME'], 'server.crt'))
-    placeholders.setdefault('SSL_PRIVATE_KEY_FILE', os.path.join(placeholders['PGHOME'], 'server.key'))
+    placeholders.setdefault('SSL_CERTIFICATE_FILE', os.path.join(placeholders['RW_DIR'], 'server.crt'))
+    placeholders.setdefault('SSL_PRIVATE_KEY_FILE', os.path.join(placeholders['RW_DIR'], 'server.key'))
     placeholders.setdefault('WALE_BACKUP_THRESHOLD_MEGABYTES', 102400)
     placeholders.setdefault('WALE_BACKUP_THRESHOLD_PERCENTAGE', 30)
     # if Kubernetes is defined as a DCS, derive the namespace from the POD_NAMESPACE, if not set explicitely.
@@ -475,7 +477,7 @@ def get_placeholders(provider):
     placeholders.setdefault('WAL_BUCKET_SCOPE_PREFIX', '{0}-'.format(placeholders['NAMESPACE'])
                             if placeholders['NAMESPACE'] not in ('default', '') else '')
     placeholders.setdefault('WAL_BUCKET_SCOPE_SUFFIX', '')
-    placeholders.setdefault('WALE_ENV_DIR', os.path.join(placeholders['PGHOME'], 'etc', 'wal-e.d', 'env'))
+    placeholders.setdefault('WALE_ENV_DIR', os.path.join(placeholders['RW_DIR'], 'etc', 'wal-e.d', 'env'))
     placeholders.setdefault('USE_WALE', False)
     cpu_count = str(min(psutil.cpu_count(), 10))
     placeholders.setdefault('WALG_DOWNLOAD_CONCURRENCY', cpu_count)
@@ -746,7 +748,7 @@ def write_wale_environment(placeholders, prefix, overwrite):
         os.makedirs(wale['WALE_ENV_DIR'])
 
     wale['WALE_LOG_DESTINATION'] = 'stderr'
-    for name in write_envdir_names + ['WALE_LOG_DESTINATION']:
+    for name in write_envdir_names + ['WALE_LOG_DESTINATION'] + ([] if prefix else ['BACKUP_NUM_TO_RETAIN']):
         if wale.get(name):
             write_file(wale[name], os.path.join(wale['WALE_ENV_DIR'], name), overwrite)
 
@@ -795,7 +797,11 @@ def write_crontab(placeholders, overwrite):
     if not (overwrite or check_crontab('postgres')):
         return
 
-    link_runit_service('cron')
+    crontabs = os.path.join(placeholders['RW_DIR'], 'cron', 'crontabs')
+    if not os.path.exists(crontabs):
+        os.makedirs(crontabs)
+        os.chmod(crontabs, 0o1730)
+    link_runit_service(placeholders, 'cron')
 
     lines = ['PATH={PATH}'.format(**placeholders)]
 
@@ -806,7 +812,7 @@ def write_crontab(placeholders, overwrite):
 
     if bool(placeholders.get('USE_WALE')):
         lines += [('{BACKUP_SCHEDULE} envdir "{WALE_ENV_DIR}" /scripts/postgres_backup.sh' +
-                   ' "{PGDATA}" {BACKUP_NUM_TO_RETAIN}').format(**placeholders)]
+                   ' "{PGDATA}"').format(**placeholders)]
 
     if bool(placeholders.get('LOG_S3_BUCKET')):
         lines += [('{LOG_SHIP_SCHEDULE} nice -n 5 envdir "{LOG_ENV_DIR}"' +
@@ -832,7 +838,7 @@ def configure_renice(overwrite):
 
 def write_etcd_configuration(placeholders, overwrite=False):
     placeholders.setdefault('ETCD_HOST', '127.0.0.1:2379')
-    link_runit_service('etcd')
+    link_runit_service(placeholders, 'etcd')
 
 
 def write_pam_oauth2_configuration(placeholders, overwrite):
@@ -856,7 +862,7 @@ def write_pgbouncer_configuration(placeholders, overwrite):
     if not pgbouncer_config:
         return logging.info('No PGBOUNCER_CONFIGURATION was specified, skipping')
 
-    pgbouncer_dir = '/run/pgbouncer'
+    pgbouncer_dir = os.path.join(placeholders['RW_DIR'], 'pgbouncer')
     if not os.path.exists(pgbouncer_dir):
         os.makedirs(pgbouncer_dir)
     write_file(pgbouncer_config, pgbouncer_dir + '/pgbouncer.ini', overwrite)
@@ -865,7 +871,7 @@ def write_pgbouncer_configuration(placeholders, overwrite):
     if pgbouncer_auth:
         write_file(pgbouncer_auth, pgbouncer_dir + '/userlist.txt', overwrite)
 
-    link_runit_service('pgbouncer')
+    link_runit_service(placeholders, 'pgbouncer')
 
 
 def get_binary_version(bin_dir):
@@ -933,7 +939,7 @@ def main():
         logging.info('Configuring %s', section)
         if section == 'patroni':
             write_file(yaml.dump(config, default_flow_style=False, width=120), patroni_configfile, args['force'])
-            link_runit_service('patroni')
+            link_runit_service(placeholders, 'patroni')
             pg_socket_dir = '/run/postgresql'
             if not os.path.exists(pg_socket_dir):
                 os.makedirs(pg_socket_dir)
@@ -962,20 +968,8 @@ def main():
             backup_label = os.path.join(pgdata, 'backup_label')
             if os.path.isfile(postmaster_pid) and os.path.isfile(backup_label):
                 os.unlink(backup_label)
-        elif section == 'patronictl':
-            configdir = os.path.join(placeholders['PGHOME'], '.config', 'patroni')
-            patronictl_configfile = os.path.join(configdir, 'patronictl.yaml')
-            if not os.path.exists(configdir):
-                os.makedirs(configdir)
-            if os.path.exists(patronictl_configfile):
-                if not args['force']:
-                    logging.warning('File %s already exists, not overriding. (Use option --force if necessary)',
-                                    patronictl_configfile)
-                    continue
-                os.unlink(patronictl_configfile)
-            os.symlink(patroni_configfile, patronictl_configfile)
         elif section == 'pgqd':
-            link_runit_service('pgqd')
+            link_runit_service(placeholders, 'pgqd')
         elif section == 'log':
             if bool(placeholders.get('LOG_S3_BUCKET')):
                 write_log_environment(placeholders)
@@ -985,7 +979,7 @@ def main():
         elif section == 'certificate':
             write_certificates(placeholders, args['force'])
         elif section == 'crontab':
-            if placeholders['CRONTAB'] or placeholders['USE_WALE'] or bool(placeholders.get('LOG_S3_BUCKET')):
+            if placeholders['CRONTAB'] != '[]' or placeholders['USE_WALE'] or bool(placeholders.get('LOG_S3_BUCKET')):
                 write_crontab(placeholders, args['force'])
         elif section == 'pam-oauth2':
             write_pam_oauth2_configuration(placeholders, args['force'])

--- a/postgres-appliance/scripts/postgres_backup.sh
+++ b/postgres-appliance/scripts/postgres_backup.sh
@@ -11,7 +11,7 @@ log "I was called as: $0 $@"
 
 
 readonly PGDATA=$1
-DAYS_TO_RETAIN=$2
+DAYS_TO_RETAIN=$BACKUP_NUM_TO_RETAIN
 
 readonly IN_RECOVERY=$(psql -tXqAc "select pg_is_in_recovery()")
 if [[ $IN_RECOVERY == "f" ]]; then


### PR DESCRIPTION
It includes moving all writable files into the `/run` directory.
In case if the file still must be located in the usual place we create a symlink.
When starting with read-only option in addition to the `/home/postgres/pgdata` volume one has to provide writable (tmpfs) `/run` volume.

Example:
```
$ docker run -v $(pwd)/pgdata:/home/postgres/pgdata \
    --tmpfs /run:rw,noexec,nosuid --read-only spilo-12
```
In addition to that, improve the `postgres_backup.sh` script. It will receive `BACKUP_NUM_TO_RETAIN` from the envdir instead of parameter.

Fixes https://github.com/zalando/spilo/issues/374