### PR TITLE
Install pglogical package for version 12

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -104,7 +104,6 @@ RUN export DEBIAN_FRONTEND=noninteractive \
             && equivs-build $p; \
         done; \
     fi \
-
 \
     && if [ "$WITH_PERL" != "true" ]; then \
         version=$(apt-cache show perl | sed -n 's/^Version: //p' | sort -rV | head -n 1) \
@@ -132,6 +131,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
             && if [ "$DEMO" != "true" ]; then \
                 EXTRAS="postgresql-pltcl-${version} \
                         postgresql-${version}-hypopg \
+                        postgresql-${version}-pg-checksums \
                         postgresql-${version}-pgq3 \
                         postgresql-${version}-pldebugger \
                         postgresql-${version}-pllua \
@@ -140,15 +140,18 @@ RUN export DEBIAN_FRONTEND=noninteractive \
                 && if [ "$WITH_PERL" = "true" ]; then \
                     EXTRAS="$EXTRAS postgresql-plperl-${version}"; \
                 fi \
-                && if [ $version != "9.3" ]; then EXTRAS="$EXTRAS postgresql-${version}-wal2json"; fi \
+                && if [ $version != "9.3" ]; then \
+                    EXTRAS="$EXTRAS postgresql-${version}-pglogical \
+                            postgresql-${version}-wal2json"; \
+                fi \
                 && if [ $version != "9.3" ] && [ $version != "9.4" ]; then \
                     EXTRAS="$EXTRAS postgresql-${version}-postgis-${POSTGIS_VERSION%.0} \
                             postgresql-${version}-postgis-${POSTGIS_VERSION%.0}-scripts"; \
                 fi \
-                && if [ $version != "9.3" ]; then \
-                    EXTRAS="$EXTRAS postgresql-${version}-pglogical" \
-                    && if [ $version != "9.4" ]; then \
-                        EXTRAS="$EXTRAS postgresql-${version}-pgl-ddl-deploy"; \
+                && if [ $version != "9.3" ] && [ $version != "12" ]; then \
+                    if [ $version != "9.4" ]; then \
+                        EXTRAS="$EXTRAS postgresql-${version}-pgl-ddl-deploy \
+                                postgresql-${version}-pglogical-ticker"; \
                     fi \
                     && if [ $version != "11" ]; then \
                         EXTRAS="$EXTRAS postgresql-${version}-amcheck"; \

--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -145,7 +145,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
                     EXTRAS="$EXTRAS postgresql-${version}-postgis-${POSTGIS_VERSION%.0} \
                             postgresql-${version}-postgis-${POSTGIS_VERSION%.0}-scripts"; \
                 fi \
-                && if [ $version != "9.3" ] && [ $version != "12" ]; then \
+                && if [ $version != "9.3" ]; then \
                     EXTRAS="$EXTRAS postgresql-${version}-pglogical" \
                     && if [ $version != "9.4" ]; then \
                         EXTRAS="$EXTRAS postgresql-${version}-pgl-ddl-deploy"; \


### PR DESCRIPTION
The necessary  pglogical version was [released](https://www.2ndquadrant.com/en/resources/pglogical/release-notes/) last week