### PR TITLE
Handle the case when value has newlines

### DIFF
--- a/postgres-appliance/runit/patroni/run
+++ b/postgres-appliance/runit/patroni/run
@@ -12,7 +12,7 @@ if ! $CHPST true 2> /dev/null; then
 fi
 
 # Only small subset of environment variables is allowed. We don't want accidentally disclose sensitive information
-for E in $(env | grep -vE '^(KUBERNETES_(SERVICE|PORT|ROLE)[_=]|((POD_(IP|NAMESPACE))|HOSTNAME|PATH|PGHOME|LC_ALL|TIMESCALEDB)=)' | sed 's/=.*//g'); do
+for E in $(printenv -0 | tr '\n' ' ' | sed 's/\x00/\n/g' | grep -vE '^(KUBERNETES_(SERVICE|PORT|ROLE)[_=]|((POD_(IP|NAMESPACE))|HOSTNAME|PATH|PGHOME|LC_ALL|TIMESCALEDB)=)' | sed 's/=.*//g'); do
     unset $E
 done
 


### PR DESCRIPTION
* `printenv -0` outputs env with null byte as delimiter
* `tr` removes all newlines
* `sed` replaces null bytes with newlines