### PR TITLE
Patroni 1.6.5

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -70,7 +70,7 @@ ENV POSTGIS_VERSION=3.0 \
     BG_MON_COMMIT=7a4a4a621f89cc032bd7d497ce2373a1220c89a5 \
     PG_AUTH_MON_COMMIT=902c670c9f2071b30e1d4437e7a38e2e136f9be6 \
     PG_MON_COMMIT=54c679478006f19df441bd98a273e2e3352690b6 \
-    DECODERBUFS=v1.1.0.Final \
+    DECODERBUFS=v1.1.1.Final \
     SET_USER=REL1_6_2 \
     PLPGSQL_CHECK=v1.9.0 \
     PLPROFILER=REL4_1 \
@@ -376,7 +376,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && find /var/log -type f -exec truncate --size 0 {} \;
 
 # Install patroni, wal-e and wal-g
-ENV PATRONIVERSION=1.6.4
+ENV PATRONIVERSION=1.6.5
 ENV WALE_VERSION=1.1.0
 ENV WALG_VERSION=v0.2.15
 RUN export DEBIAN_FRONTEND=noninteractive \

--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -1,6 +1,6 @@
 ARG PGVERSION=12
-ARG TIMESCALEDB=1.6.1
-ARG TIMESCALEDB_LEGACY=$TIMESCALEDB
+ARG TIMESCALEDB=1.7.0
+ARG TIMESCALEDB_LEGACY=1.6.1
 ARG DEMO=false
 ARG COMPRESS=false
 
@@ -168,11 +168,12 @@ RUN export DEBIAN_FRONTEND=noninteractive \
                         libpq-dev=$version* postgresql-server-dev-${version} \
 \
             # Install 3rd party stuff
-            && if [ "$version" = "9.6" ] || [ "$version" = "10" ] || [ "$version" = "11" ] ; then \
+            && if [ "$version" != "9.5" ]; then \
                 cd timescaledb \
-                && if [ "$version" != "9.6" ]; then git checkout $TIMESCALEDB; fi \
+                && if [ "$version" = "12" ]; then git checkout $TIMESCALEDB; fi \
                 && rm -fr build \
-                && ./bootstrap -DAPACHE_ONLY=$TIMESCALEDB_APACHE_ONLY -DSEND_TELEMETRY_DEFAULT=NO -DREGRESS_CHECKS=OFF \
+                && ./bootstrap -DAPACHE_ONLY=$TIMESCALEDB_APACHE_ONLY -DSEND_TELEMETRY_DEFAULT=NO \
+                    -DREGRESS_CHECKS=OFF -DPG_CONFIG=/usr/lib/postgresql/$version/bin/pg_config \
                 && make -C build install \
                 && strip /usr/lib/postgresql/$version/lib/timescaledb*.so \
                 && cd ..; \
@@ -187,7 +188,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
                 fi \
 \
                 && EXTRA_EXTENSIONS="plantuner-${PLANTUNER_COMMIT} plpgsql_check plprofiler postgres-decoderbufs" \
-                && if [ "$version" = "10" ] || [ "$version" = "11" ] || [ "$version" = "12" ] ; then \
+                && if [ "$version" = "10" ] || [ "$version" = "11" ] || [ "$version" = "12" ]; then \
                      EXTRA_EXTENSIONS="$EXTRA_EXTENSIONS pg_mon-${PG_MON_COMMIT}"; \
                 fi; \
             else \

--- a/postgres-appliance/bootstrap/pg_upgrade.py
+++ b/postgres-appliance/bootstrap/pg_upgrade.py
@@ -18,7 +18,7 @@ class PostgresqlUpgrade(Postgresql):
         self._old_config_values['shared_preload_libraries'] = shared_preload_libraries
 
         extensions = {
-            'timescaledb':    (9.6, 11),
+            'timescaledb':    (9.6, 12),
             'pg_cron':        (9.5, 12),
             'pg_stat_kcache': (9.4, 12),
             'pg_partman':     (9.4, 12)

--- a/postgres-appliance/launch.sh
+++ b/postgres-appliance/launch.sh
@@ -40,7 +40,7 @@ if [ "$DEMO" = "true" ]; then
     python3 /scripts/configure_spilo.py patroni pgqd certificate pam-oauth2
 elif python3 /scripts/configure_spilo.py all; then
     CMD="/scripts/patroni_wait.sh -t 3600 -- envdir $WALE_ENV_DIR /scripts/postgres_backup.sh $PGDATA"
-    if [ "$(id -u)" -ne 0 ]; then
+    if [ "$(id -u)" = "0" ]; then
         su postgres -c "PATH=$PATH $CMD" &
     else
         $CMD &

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -33,7 +33,7 @@ MEMORY_LIMIT_IN_BYTES_PATH = '/sys/fs/cgroup/memory/memory.limit_in_bytes'
 
 # (min_version, max_version, shared_preload_libraries, extwlist.extensions)
 extensions = {
-    'timescaledb':    (9.6, 11, True,  True),
+    'timescaledb':    (9.6, 12, True,  True),
     'pg_cron':        (9.5, 12, True,  False),
     'pg_stat_kcache': (9.4, 12, True,  False),
     'pg_partman':     (9.4, 12, False, True)

--- a/postgres-appliance/scripts/post_init.sh
+++ b/postgres-appliance/scripts/post_init.sh
@@ -138,7 +138,7 @@ while IFS= read -r db_name; do
     # ERROR:  could not access file "$libdir/timescaledb-$OLD_VERSION": No such file or directory
     TIMESCALEDB_VERSION=$(echo -e "SELECT NULL;\nSELECT extversion FROM pg_catalog.pg_extension WHERE extname = 'timescaledb'" | psql -tAX -d "${db_name}" 2> /dev/null | tail -n 1)
     if [ "x$TIMESCALEDB_VERSION" != "x" ] && [ "x$TIMESCALEDB_VERSION" != "x$TIMESCALEDB" ] \
-            && [ $PGVER -gt 9 -o "x$TIMESCALEDB_VERSION" != "x$TIMESCALEDB_LEGACY" ]; then
+            && [ $PGVER -gt 11 -o "x$TIMESCALEDB_VERSION" != "x$TIMESCALEDB_LEGACY" ]; then
         echo "ALTER EXTENSION timescaledb UPDATE;"
     fi
     UPGRADE_POSTGIS=$(echo -e "SELECT COUNT(*) FROM pg_catalog.pg_extension WHERE extname = 'postgis'" | psql -tAX -d "${db_name}" 2> /dev/null | tail -n 1)


### PR DESCRIPTION
* bump Patroni version to 1.6.5
* bump debezium to v1.1.1.Final
* fix a bug in the launch.sh
* add timescaledb 1.7.0 for postgres 12 (older postgres versions stick to 1.6.1, because 1.7.0 has some bugs)

Close https://github.com/zalando/postgres-operator/issues/929
Close https://github.com/zalando/spilo/issues/417