### PR TITLE
use AWS_REGION when provided

### DIFF
--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -717,6 +717,8 @@ def write_wale_environment(placeholders, prefix, overwrite):
             else:
                 aws_region = placeholders['instance_data']['zone'][:-1]
             wale['AWS_REGION'] = aws_region
+        else:
+            wale['AWS_REGION'] = aws_region
 
         if not (wale.get('AWS_SECRET_ACCESS_KEY') and wale.get('AWS_ACCESS_KEY_ID')):
             wale['AWS_INSTANCE_PROFILE'] = 'true'


### PR DESCRIPTION
When AWS_REGION is supplied it is ignored when using AWS S3 storage
resolves #477