### PR TITLE
bugfix/issue479  Make sure created certificate are owned by postgres user

### DIFF
--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -107,7 +107,7 @@ def write_certificates(environment, overwrite):
         output, _ = p.communicate()
         logging.debug(output)
 
-    uid = pwd.getpwnam(environment['PGUSER_SUPERUSER']).pw_uid
+    uid = pwd.getpwnam('postgres').pw_uid
     os.chmod(environment['SSL_PRIVATE_KEY_FILE'], 0o600)
     os.chown(environment['SSL_PRIVATE_KEY_FILE'], uid, -1)
 


### PR DESCRIPTION
The owner of the certificates doesn't need to be customized  as there is only one possible option postgres.
This reduce that possibility that an user by mistake set a different user which cause the failure of the  bootstrap.