### PR TITLE
Disable prefetch when restore_command is called for pg_rewind

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,13 +21,14 @@ How to Build This Docker Image
 
     $ cd postgres-appliance
 
-    $ ./build.sh --build-arg COMPRESS=true --tag $YOUR_TAG .
+    $ docker build --tag $YOUR_TAG .
 
-Other build arguments and their default values:
+
+There are a few build arguments defined in the Dockerfile and it is possible to change them by specifying ``--build-arg`` arguments:
 
 - WITH_PERL=false # set to true if you want to install perl and plperl packages into image
-- PGVERSION="11"
-- PGOLDVERSIONS="9.3 9.4 9.5 9.6 10"
+- PGVERSION="12"
+- PGOLDVERSIONS="9.5 9.6 10 11"
 - DEMO=false # set to true to build the smallest possible image which will work only on Kubernetes
 - TIMESCALEDB_APACHE_ONLY=true # set to false to build timescaledb community version (Timescale License)
 

--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -376,7 +376,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 # Install patroni, wal-e and wal-g
 ENV PATRONIVERSION=2.0.0
 ENV WALE_VERSION=1.1.1
-ENV WALG_VERSION=v0.2.17
+ENV WALG_VERSION=v0.2.15
 RUN export DEBIAN_FRONTEND=noninteractive \
     && set -ex \
     && BUILD_PACKAGES="python3-pip python3-wheel python3-dev git patchutils binutils" \

--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -71,7 +71,7 @@ ENV POSTGIS_VERSION=3.0 \
     PG_AUTH_MON_COMMIT=902c670c9f2071b30e1d4437e7a38e2e136f9be6 \
     PG_MON_COMMIT=cc028fdae8542ec3f5df3bf4c66f0895d87c127d \
     DECODERBUFS=v1.2.1.Final \
-    SET_USER=REL1_6_2 \
+    SET_USER=REL2_0_0 \
     PLPROFILER=REL4_1 \
     PAM_OAUTH2=v1.0.1 \
     PLANTUNER_COMMIT=800d81bc85da64ff3ef66e12aed1d4e1e54fc006
@@ -414,6 +414,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         && sed -i 's/^\(    for i in range(0,\) num_retries):.*/\1 100):/g' /usr/lib/python3/dist-packages/boto/utils.py; \
     fi \
     && pip3 install patroni[kubernetes$EXTRAS]==$PATRONIVERSION \
+    && pip3 install "git+https://github.com/zalando/patroni.git@2.0/bugfixes#egg=patroni[kubernetes$EXTRAS]" \
 \
     && for d in /usr/local/lib/python3.6 /usr/lib/python3; do \
         cd $d/dist-packages \

--- a/postgres-appliance/scripts/restore_command.sh
+++ b/postgres-appliance/scripts/restore_command.sh
@@ -12,19 +12,22 @@ readonly wal_fast_source=$(dirname "$(dirname "$(realpath "$wal_dir")")")/wal_fa
 
 if [[ "$wal_destination" =~ /$wal_filename$ ]]; then  # Patroni fetching missing files for pg_rewind
     export WALG_DOWNLOAD_CONCURRENCY=1
+    POOL_SIZE=0
+else
+    POOL_SIZE=$WALG_DOWNLOAD_CONCURRENCY
 fi
 
 [[ "$USE_WALG_RESTORE" == "true" ]] && exec wal-g wal-fetch "${wal_filename}" "${wal_destination}"
 
-[[ $WALG_DOWNLOAD_CONCURRENCY -gt 8 ]] && WALG_DOWNLOAD_CONCURRENCY=8
+[[ $POOL_SIZE -gt 8 ]] && POOL_SIZE=8
 
 if [[ -z $WALE_S3_PREFIX ]]; then  # non AWS environment?
     readonly wale_prefetch_source=${wal_dir}/.wal-e/prefetch/${wal_filename}
     if [[ -f $wale_prefetch_source ]]; then
         exec mv "${wale_prefetch_source}" "${wal_destination}"
     else
-        exec wal-e wal-fetch -p $WALG_DOWNLOAD_CONCURRENCY "${wal_filename}" "${wal_destination}"
+        exec wal-e wal-fetch -p $POOL_SIZE "${wal_filename}" "${wal_destination}"
     fi
 else
-    exec bash /scripts/wal-e-wal-fetch.sh wal-fetch -p $WALG_DOWNLOAD_CONCURRENCY "${wal_filename}" "${wal_destination}"
+    exec bash /scripts/wal-e-wal-fetch.sh wal-fetch -p $POOL_SIZE "${wal_filename}" "${wal_destination}"
 fi

--- a/postgres-appliance/scripts/restore_command.sh
+++ b/postgres-appliance/scripts/restore_command.sh
@@ -10,18 +10,21 @@ readonly wal_fast_source=$(dirname "$(dirname "$(realpath "$wal_dir")")")/wal_fa
 
 [[ -f $wal_fast_source ]] && exec mv "${wal_fast_source}" "${wal_destination}"
 
+if [[ "$wal_destination" =~ /$wal_filename$ ]]; then  # Patroni fetching missing files for pg_rewind
+    export WALG_DOWNLOAD_CONCURRENCY=1
+fi
+
 [[ "$USE_WALG_RESTORE" == "true" ]] && exec wal-g wal-fetch "${wal_filename}" "${wal_destination}"
 
-POOL_SIZE=$(($(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1)-1))
-[[ $POOL_SIZE -gt 8 ]] && POOL_SIZE=8
+[[ $WALG_DOWNLOAD_CONCURRENCY -gt 8 ]] && WALG_DOWNLOAD_CONCURRENCY=8
 
 if [[ -z $WALE_S3_PREFIX ]]; then  # non AWS environment?
     readonly wale_prefetch_source=${wal_dir}/.wal-e/prefetch/${wal_filename}
     if [[ -f $wale_prefetch_source ]]; then
         exec mv "${wale_prefetch_source}" "${wal_destination}"
     else
-        exec wal-e wal-fetch -p $POOL_SIZE "${wal_filename}" "${wal_destination}"
+        exec wal-e wal-fetch -p $WALG_DOWNLOAD_CONCURRENCY "${wal_filename}" "${wal_destination}"
     fi
 else
-    exec bash /scripts/wal-e-wal-fetch.sh wal-fetch -p $POOL_SIZE "${wal_filename}" "${wal_destination}"
+    exec bash /scripts/wal-e-wal-fetch.sh wal-fetch -p $WALG_DOWNLOAD_CONCURRENCY "${wal_filename}" "${wal_destination}"
 fi


### PR DESCRIPTION
We use the fact that `%p` parameter contains either `RECOVERYHISTORY` or `RECOVERYXLOG`, but in case of pg_rewind the file is being restored directly to `pg_wal/%f`
If it is detected, the following is done:
* export WALG_DOWNLOAD_CONCURRENCY=1 environment for wal-g
* Use -p 1 option for wal-e

In addition to that update README.rst and bump some dependencies.