### PR TITLE
Fix problems with build

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -162,8 +162,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 \
             # Install PostgreSQL binaries, contrib, plproxy and multiple pl's
             && apt-get install --allow-downgrades -y postgresql-contrib-${version} \
-                        postgresql-plpython3-${version} libpq5=$version* $EXTRAS \
-                        libpq-dev=$version* postgresql-server-dev-${version} \
+                    postgresql-plpython3-${version} postgresql-server-dev-${version} $EXTRAS \
 \
             # Install 3rd party stuff
             && if [ "$version" != "9.5" ]; then \
@@ -195,9 +194,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 \
             && for n in bg_mon-${BG_MON_COMMIT} pg_auth_mon-${PG_AUTH_MON_COMMIT} set_user $EXTRA_EXTENSIONS; do \
                 make -C $n USE_PGXS=1 clean install-strip; \
-            done \
-\
-            && apt-get purge -y libpq-dev=$version*; \
+            done; \
     done \
 \
     && apt-get install -y skytools3-ticker \
@@ -248,7 +245,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     done \
 \
     # Remove unnecessary packages
-    && apt-get purge -y ${BUILD_PACKAGES} postgresql postgresql-server-dev-* libpq-dev=$PGVERSION* libmagic1 bsdmainutils \
+    && apt-get purge -y ${BUILD_PACKAGES} postgresql postgresql-server-dev-* libpq-dev=* libmagic1 bsdmainutils \
     && apt-get autoremove -y \
     && apt-get clean \
     && dpkg -l | grep '^rc' | awk '{print $2}' | xargs apt-get purge -y \
@@ -413,7 +410,6 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         # https://github.com/wal-e/wal-e/issues/318
         && sed -i 's/^\(    for i in range(0,\) num_retries):.*/\1 100):/g' /usr/lib/python3/dist-packages/boto/utils.py; \
     fi \
-    && pip3 install patroni[kubernetes$EXTRAS]==$PATRONIVERSION \
     && pip3 install "git+https://github.com/zalando/patroni.git@2.0/bugfixes#egg=patroni[kubernetes$EXTRAS]" \
 \
     && for d in /usr/local/lib/python3.6 /usr/lib/python3; do \

--- a/postgres-appliance/scripts/post_init.sh
+++ b/postgres-appliance/scripts/post_init.sh
@@ -131,9 +131,6 @@ done
 
 cat _zmon_schema.dump
 
-PGVER=$(psql -d "$2" -XtAc "SELECT pg_catalog.current_setting('server_version_num')::int/10000")
-if [ "$PGVER" -ge 12 ]; then RESET_ARGS="oid, oid, bigint"; fi
-
 while IFS= read -r db_name; do
     echo "\c ${db_name}"
     # In case if timescaledb binary is missing the first query fails with the error


### PR DESCRIPTION
* Don't install/purge libpq with pinned version. It was required only for building pg_rewind on 9.3 and 9.4.
* Fix Patroni install
* Clean up post_init.sh