### PR TITLE
Support for additional locales

### DIFF
--- a/ENVIRONMENT.rst
+++ b/ENVIRONMENT.rst
@@ -75,4 +75,4 @@ Environment Configuration Settings
 - **KUBERNETES_ROLE_LABEL**: name of the label containing Postgres role when running on Kubernetens. Default is 'spilo-role'.
 - **KUBERNETES_SCOPE_LABEL**: name of the label containing cluster name. Default is 'version'.
 - **KUBERNETES_LABELS**: a JSON describing names and values of other labels used by Patroni on Kubernetes to locate its metadata. Default is '{"application": "spilo"}'.
-- **INITDB_LOCALE**: database cluster's default locale (en_US by default)
+- **INITDB_LOCALE**: database cluster's default UTF-8 locale (en_US by default)

--- a/ENVIRONMENT.rst
+++ b/ENVIRONMENT.rst
@@ -75,3 +75,4 @@ Environment Configuration Settings
 - **KUBERNETES_ROLE_LABEL**: name of the label containing Postgres role when running on Kubernetens. Default is 'spilo-role'.
 - **KUBERNETES_SCOPE_LABEL**: name of the label containing cluster name. Default is 'version'.
 - **KUBERNETES_LABELS**: a JSON describing names and values of other labels used by Patroni on Kubernetes to locate its metadata. Default is '{"application": "spilo"}'.
+- **INITDB_LOCALE**: database cluster's default locale (en_US by default)

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,7 @@ There are a few build arguments defined in the Dockerfile and it is possible to 
 - PGOLDVERSIONS="9.5 9.6 10 11"
 - DEMO=false # set to true to build the smallest possible image which will work only on Kubernetes
 - TIMESCALEDB_APACHE_ONLY=true # set to false to build timescaledb community version (Timescale License)
+- ADDITIONAL_LOCALES= # comma separated locales to build into image (example: de_DE,pl_PL)
 
 Run the image locally after build:
 

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ There are a few build arguments defined in the Dockerfile and it is possible to 
 - PGOLDVERSIONS="9.5 9.6 10 11"
 - DEMO=false # set to true to build the smallest possible image which will work only on Kubernetes
 - TIMESCALEDB_APACHE_ONLY=true # set to false to build timescaledb community version (Timescale License)
-- ADDITIONAL_LOCALES= # comma separated locales to build into image (example: de_DE,pl_PL)
+- ADDITIONAL_LOCALES= # additional UTF-8 locales to build into image (example: "de_DE pl_PL fr_FR")
 
 Run the image locally after build:
 

--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -3,8 +3,11 @@ ARG TIMESCALEDB=1.7.4
 ARG TIMESCALEDB_LEGACY=1.7.4
 ARG DEMO=false
 ARG COMPRESS=false
+ARG ADDITIONAL_LOCALES=
 
 FROM ubuntu:18.04 as builder-false
+
+ARG ADDITIONAL_LOCALES
 
 RUN export DEBIAN_FRONTEND=noninteractive \
     && echo 'APT::Install-Recommends "0";\nAPT::Install-Suggests "0";' > /etc/apt/apt.conf.d/01norecommend \
@@ -25,13 +28,23 @@ RUN export DEBIAN_FRONTEND=noninteractive \
                 | tar xz -C /bin --strip=1 --wildcards --no-anchored etcdctl etcd; \
     fi \
 \
-    # Cleanup all locales but en_US.UTF-8
+    # Prepare find expression for ADDITIONAL_LOCALES
+    && for ADDITIONAL_LOCALE in $(echo $ADDITIONAL_LOCALES | sed "s/,/ /g"); do \
+        ADDITIONAL_LOCALE_FIND_EXPR="${ADDITIONAL_LOCALE_FIND_EXPR} ! -name ${ADDITIONAL_LOCALE}"; \
+    done \
+    # Cleanup all locales but en_US.UTF-8 and optionally specified in ADDITIONAL_LOCALES arg
     && find /usr/share/i18n/charmaps/ -type f ! -name UTF-8.gz -delete \
-    && find /usr/share/i18n/locales/ -type f ! -name en_US ! -name en_GB ! -name i18n* ! -name iso14651_t1 ! -name iso14651_t1_common ! -name 'translit_*' -delete \
+    && find /usr/share/i18n/locales/ -type f ! -name en_US ! -name en_GB ${ADDITIONAL_LOCALE_FIND_EXPR} ! -name i18n* ! -name iso14651_t1 ! -name iso14651_t1_common ! -name 'translit_*' -delete \
     && echo 'en_US.UTF-8 UTF-8' > /usr/share/i18n/SUPPORTED \
 \
-    ## Make sure we have a en_US.UTF-8 locale available
+    # Make sure we have a en_US.UTF-8 locale available
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
+\
+    # Make sure we have all additional locales available
+    && for ADDITIONAL_LOCALE in $(echo $ADDITIONAL_LOCALES | sed "s/,/ /g"); do \
+        echo "${ADDITIONAL_LOCALE}.UTF-8 UTF-8" >> /usr/share/i18n/SUPPORTED; \
+        localedef -i ${ADDITIONAL_LOCALE} -c -f UTF-8 -A /usr/share/locale/locale.alias ${ADDITIONAL_LOCALE}.UTF-8; \
+    done \
 \
     # Add PGDG repositories
     && DISTRIB_CODENAME=$(sed -n 's/DISTRIB_CODENAME=//p' /etc/lsb-release) \

--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -3,11 +3,10 @@ ARG TIMESCALEDB=1.7.4
 ARG TIMESCALEDB_LEGACY=1.7.4
 ARG DEMO=false
 ARG COMPRESS=false
-ARG ADDITIONAL_LOCALES=
 
 FROM ubuntu:18.04 as builder-false
 
-ARG ADDITIONAL_LOCALES
+ARG ADDITIONAL_LOCALES=
 
 RUN export DEBIAN_FRONTEND=noninteractive \
     && echo 'APT::Install-Recommends "0";\nAPT::Install-Suggests "0";' > /etc/apt/apt.conf.d/01norecommend \
@@ -29,8 +28,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     fi \
 \
     # Prepare find expression for ADDITIONAL_LOCALES
-    && for ADDITIONAL_LOCALE in $(echo $ADDITIONAL_LOCALES | sed "s/,/ /g"); do \
-        ADDITIONAL_LOCALE_FIND_EXPR="${ADDITIONAL_LOCALE_FIND_EXPR} ! -name ${ADDITIONAL_LOCALE}"; \
+    && for loc in $ADDITIONAL_LOCALES; do \
+        ADDITIONAL_LOCALE_FIND_EXPR="${ADDITIONAL_LOCALE_FIND_EXPR} ! -name ${loc}"; \
     done \
     # Cleanup all locales but en_US.UTF-8 and optionally specified in ADDITIONAL_LOCALES arg
     && find /usr/share/i18n/charmaps/ -type f ! -name UTF-8.gz -delete \
@@ -41,9 +40,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
 \
     # Make sure we have all additional locales available
-    && for ADDITIONAL_LOCALE in $(echo $ADDITIONAL_LOCALES | sed "s/,/ /g"); do \
-        echo "${ADDITIONAL_LOCALE}.UTF-8 UTF-8" >> /usr/share/i18n/SUPPORTED; \
-        localedef -i ${ADDITIONAL_LOCALE} -c -f UTF-8 -A /usr/share/locale/locale.alias ${ADDITIONAL_LOCALE}.UTF-8; \
+    && for loc in $ADDITIONAL_LOCALES; do \
+        echo "${loc}.UTF-8 UTF-8" >> /usr/share/i18n/SUPPORTED; \
+        localedef -i ${loc} -c -f UTF-8 -A /usr/share/locale/locale.alias ${loc}.UTF-8; \
     done \
 \
     # Add PGDG repositories

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -216,7 +216,7 @@ bootstrap:
   {{/CLONE_WITH_BASEBACKUP}}
   initdb:
     - encoding: UTF8
-    - locale: en_US.UTF-8
+    - locale: {{INITDB_LOCALE}}.UTF-8
     - data-checksums
   {{#USE_ADMIN}}
   users:
@@ -485,6 +485,7 @@ def get_placeholders(provider):
     placeholders.setdefault('SSL_PRIVATE_KEY_FILE', os.path.join(placeholders['RW_DIR'], 'certs', 'server.key'))
     placeholders.setdefault('WALE_BACKUP_THRESHOLD_MEGABYTES', 102400)
     placeholders.setdefault('WALE_BACKUP_THRESHOLD_PERCENTAGE', 30)
+    placeholders.setdefault('INITDB_LOCALE', 'en_US')
     # if Kubernetes is defined as a DCS, derive the namespace from the POD_NAMESPACE, if not set explicitely.
     # We only do this for Kubernetes DCS, as we don't want to suddently change, i.e. DCS base path when running
     # in Kubernetes with Etcd in a non-default namespace


### PR DESCRIPTION
Support for additional UTF-8 locales build into image by specify build-arg - #346

You can specify **ADDITIONAL_LOCALES** build-arg as comma separated list of locales to build into image (example: _de_DE,pl_PL_). You can also specify environment variable **INITDB_LOCALE** when running image as container to change database cluster's default locale.