### PR TITLE
Use an IP address for Google instance metadata

### DIFF
--- a/postgres-appliance/launch.sh
+++ b/postgres-appliance/launch.sh
@@ -53,6 +53,8 @@ sv_stop() {
     sv -w 86400 stop /etc/service/*
 }
 
+[ ! -d /etc/service ] && exit 1 # /etc/service has not been created due to an error, the container is no-op
+
 trap sv_stop TERM QUIT INT
 
 /usr/bin/runsvdir -P /etc/service &

--- a/postgres-appliance/launch.sh
+++ b/postgres-appliance/launch.sh
@@ -53,7 +53,7 @@ sv_stop() {
     sv -w 86400 stop /etc/service/*
 }
 
-[ ! -d /etc/service ] && exit 1 # /etc/service has not been created due to an error, the container is no-op
+[ ! -d /etc/service ] && exit 1  # /etc/service has not been created due to an error, the container is no-op
 
 trap sv_stop TERM QUIT INT
 

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -376,7 +376,7 @@ def get_instance_metadata(provider):
     headers = {}
     if provider == PROVIDER_GOOGLE:
         headers['Metadata-Flavor'] = 'Google'
-        url = 'http://metadata.google.internal/computeMetadata/v1/instance'
+        url = 'http://169.254.169.254/computeMetadata/v1/instance' # metadata.google.internal
         mapping = {'zone': 'zone'}
         if not USE_KUBERNETES:
             mapping.update({'id': 'id'})

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -376,7 +376,7 @@ def get_instance_metadata(provider):
     headers = {}
     if provider == PROVIDER_GOOGLE:
         headers['Metadata-Flavor'] = 'Google'
-        url = 'http://169.254.169.254/computeMetadata/v1/instance' # metadata.google.internal
+        url = 'http://169.254.169.254/computeMetadata/v1/instance'  # metadata.google.internal
         mapping = {'zone': 'zone'}
         if not USE_KUBERNETES:
             mapping.update({'id': 'id'})


### PR DESCRIPTION
Makes Spilo start even if external DNS queries from
within the container are not working.

Do not continue with the startup when /etc/service is missing.

Per https://github.com/zalando/spilo/issues/511