### PR TITLE
Fix metadata service for OpenStack

### DIFF
--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -389,7 +389,7 @@ def get_instance_metadata(provider):
         mapping = {}  # Disable multi-url fetch
         url = 'http://169.254.169.254/openstack/latest/meta_data.json'
         openstack_metadata = requests.get(url, timeout=5).json()
-        metadata['zone'] = openstack_metadata.availability_zone
+        metadata['zone'] = openstack_metadata['availability_zone']
         if not USE_KUBERNETES:
             # OpenStack does not support providing an IP through metadata so keep
             # auto-discovered one.


### PR DESCRIPTION
requests.get().json() returns a dict and not an object.

fixes #525

@baylisscg you contributed the change a few months ago in https://github.com/zalando/spilo/pull/486/files. Maybe you could have a look at this change and the issue #525 and provide some feedback if you agree with it or if you see an issue?