### PR TITLE
Postgis 3.1, timescale 2.0 and a few optimizations in relinking of extensions/contribs

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -79,7 +79,8 @@ ARG WITH_PERL=false
 ARG DEB_PG_SUPPORTED_VERSIONS="$PGOLDVERSIONS $PGVERSION"
 
 # Install PostgreSQL, extensions and contribs
-ENV POSTGIS_VERSION=3.0 \
+ENV POSTGIS_VERSION=3.1 \
+    POSTGIS_LEGACY=3.0 \
     BG_MON_COMMIT=8a21dc39c9fdb20cbd37327d8e0f531755f5dd80 \
     PG_AUTH_MON_COMMIT=a0c086ad9865c9a0f468f12d09b77353acd2de28 \
     PG_MON_COMMIT=12bdfa8d93294fb596c9066bc7e6f73bfead35da \
@@ -160,8 +161,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
                         postgresql-${version}-pllua \
                         postgresql-${version}-plpgsql-check \
                         postgresql-${version}-plproxy \
-                        postgresql-${version}-postgis-${POSTGIS_VERSION%.0} \
-                        postgresql-${version}-postgis-${POSTGIS_VERSION%.0}-scripts \
+                        postgresql-${version}-postgis-${POSTGIS_VERSION%.*} \
+                        postgresql-${version}-postgis-${POSTGIS_VERSION%.*}-scripts \
                         postgresql-${version}-repack \
                         postgresql-${version}-wal2json" \
                 && if [ "$WITH_PERL" = "true" ]; then \
@@ -225,7 +226,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
             # due to dependency issues partman has to be installed separately
             apt-get install -y postgresql-${version}-partman \
             # create postgis symlinks to make it possible to perform update
-            && ln -s postgis-${POSTGIS_VERSION%.0}.so \
+            && ln -s postgis-${POSTGIS_VERSION%.*}.so \
                 /usr/lib/postgresql/${version}/lib/postgis-2.5.so; \
         done \
         # patch, build and install pgbouncer
@@ -276,92 +277,55 @@ RUN export DEBIAN_FRONTEND=noninteractive \
                 fi; \
             done; \
         done \
-\
-        && PGVERSION=12 \
-        && cd /usr/share/postgresql/$PGVERSION/contrib/postgis-$POSTGIS_VERSION \
-        && for f in *.sql *.pl; do \
-            for v in /usr/share/postgresql/*; do \
-                if [ "$v" != "/usr/share/postgresql/$PGVERSION" ] && diff $v/contrib/postgis-$POSTGIS_VERSION/$f $f > /dev/null; then \
-                    rm $v/contrib/postgis-$POSTGIS_VERSION/$f \
-                    && ln -s ../../../$PGVERSION/contrib/postgis-$POSTGIS_VERSION/$f $v/contrib/postgis-$POSTGIS_VERSION/$f; \
-                fi; \
-            done; \
-        done \
-\
-        && if [ -d /usr/share/postgresql/9.5/contrib/postgis-$POSTGIS_VERSION ]; then \
-            cd /usr/share/postgresql/9.5/contrib/postgis-$POSTGIS_VERSION \
-            && for f in *.sql *.pl; do \
-                if [ -L $f ]; then continue; fi \
-                && for v in /usr/share/postgresql/*; do \
-                    if [ "$v" != "/usr/share/postgresql/9.5" ] && [ -f $v/contrib/postgis-$POSTGIS_VERSION/$f ] \
-                            && [ ! -L $v/contrib/postgis-$POSTGIS_VERSION/$f ] \
-                            && diff $v/contrib/postgis-$POSTGIS_VERSION/$f $f > /dev/null; then \
-                        rm $v/contrib/postgis-$POSTGIS_VERSION/$f \
-                        && ln -s ../../../9.5/contrib/postgis-$POSTGIS_VERSION/$f \
-                                $v/contrib/postgis-$POSTGIS_VERSION/$f; \
+        && set +x \
+        && for v1 in $(ls -1d /usr/share/postgresql/* | sort -Vr); do \
+            # relink files with the same content
+            cd $v1/extension \
+            && for orig in $(ls -1 *.sql | grep -v -- '--'); do \
+                for f in ${orig%.sql}--*.sql; do \
+                    if [ ! -L $f ] && diff $orig $f > /dev/null; then \
+                        echo "creating symlink $f -> $orig" \
+                        && rm $f && ln -s $orig $f; \
                     fi; \
                 done; \
-            done; \
-        fi \
-\
-        && cd /usr/share/postgresql/$PGVERSION/extension \
-        && for orig in $(ls -1 *.sql | grep -v -- '--'); do \
-            for f in ${orig%.sql}--*.sql; do \
-                if diff $orig $f > /dev/null; then \
-                    rm $f \
-                    && ln -s $orig $f; \
+            done \
+            && for e in pgq plproxy address_standardizer address_standardizer_data_us; do \
+                orig=$(ls -1 $e--*--*.sql 2> /dev/null | head -n1) \
+                && if [ "x$orig" != "x" ]; then \
+                    for f in $e--*--*.sql; do \
+                        if [ "$f" != "$orig" ] && [ ! -L $f ] && diff $f $orig > /dev/null; then \
+                            echo "creating symlink $f -> $orig" \
+                            && rm $f && ln -s $orig $f; \
+                        fi; \
+                    done; \
+                fi; \
+            done \
+            # relink files with the same name and content across different major versions
+            && started=0 \
+            && for v2 in $(ls -1d /usr/share/postgresql/* | sort -Vr); do \
+                if [ $v1 = $v2 ]; then \
+                    started=1; \
+                elif [ $started = 1 ]; then \
+                    for d1 in extension contrib contrib/postgis-$POSTGIS_VERSION; do \
+                        cd $v1/$d1 \
+                        && d2="$d1" \
+                        && d1="../../${v1##*/}/$d1" \
+                        && if [ "${d2%-*}" = "contrib/postgis" ]; then \
+                            if  [ "${v2##*/}" = "9.5" ]; then d2="${d2%-*}-$POSTGIS_LEGACY"; fi \
+                            && d1="../$d1"; \
+                        fi \
+                        && d2="$v2/$d2" \
+                        && for f in *.html *.sql *.control *.pl; do \
+                            if [ -f $d2/$f ] && [ ! -L $d2/$f ] && diff $d2/$f $f > /dev/null; then \
+                                echo "creating symlink $d2/$f -> $d1/$f" \
+                                && rm $d2/$f && ln -s $d1/$f $d2/$f; \
+                            fi; \
+                        done; \
+                    done; \
                 fi; \
             done; \
         done \
-\
-        && for e in pgq plproxy address_standardizer address_standardizer_data_us; do \
-            orig=$(ls -1 $e--*--*.sql 2> /dev/null | head -n1) \
-            && if [ "x$orig" != "x" ]; then \
-                for f in $e--*--*.sql; do \
-                    if [ "$f" != "$orig" ] && diff $f $orig > /dev/null; then \
-                        rm $f \
-                        && ln -s $orig $f; \
-                    fi; \
-                done; \
-            fi; \
-        done \
-\
-        && for f in *.sql *.control; do \
-            for v in /usr/share/postgresql/*; do \
-                if [ "$v" != "/usr/share/postgresql/$PGVERSION" ] \
-                        && [ -f $v/extension/$f ] \
-                        && [ ! -L $v/extension/$f ] \
-                        && diff $v/extension/$f $f > /dev/null; then \
-                    rm $v/extension/$f \
-                    && ln -s ../../$PGVERSION/extension/$f $v/extension/$f; \
-                fi; \
-            done; \
-        done \
-\
-        && if [ -d /usr/share/postgresql/9.5/extension ]; then \
-            cd /usr/share/postgresql/9.5/extension \
-            && for f in *.sql *.control; do \
-                if [ -L $f ]; then continue; fi \
-                && for v in /usr/share/postgresql/*; do \
-                    if [ "$v" != "/usr/share/postgresql/9.5" ] && [ -f $v/extension/$f ] \
-                            && [ ! -L $v/extension/$f ] \
-                            && diff $v/extension/$f $f > /dev/null; then \
-                        rm $v/extension/$f \
-                        && ln -s ../../9.5/extension/$f $v/extension/$f; \
-                   fi; \
-                done; \
-            done; \
-        fi \
-\
-        && cd /usr/share/postgresql/$PGVERSION/contrib \
-        && for f in *.sql *.html; do \
-            for v in /usr/share/postgresql/*; do \
-                if [ "$v" != "/usr/share/postgresql/$PGVERSION" ] && diff $v/contrib/$f $f > /dev/null; then \
-                    rm $v/contrib/$f \
-                    && ln -s ../../$PGVERSION/contrib/$f $v/contrib/$f; \
-                fi; \
-            done; \
-        done; \
+        && set -x; \
     fi \
 \
     # Clean up

--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -136,7 +136,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && curl -sL https://github.com/CyberDem0n/pg_auth_mon/archive/$PG_AUTH_MON_COMMIT.tar.gz | tar xz \
     && curl -sL https://github.com/cybertec-postgresql/pg_permission/archive/$PG_PERMISSIONS_COMMIT.tar.gz | tar xz \
     && git clone -b $SET_USER https://github.com/pgaudit/set_user.git \
-    && git clone -b $TIMESCALEDB_LEGACY https://github.com/timescale/timescaledb.git \
+    && git clone https://github.com/timescale/timescaledb.git \
 \
     && apt-get install -y postgresql-common libevent-2.1 libevent-pthreads-2.1 sysstat brotli libbrotli1 python3.6 python3-psycopg2 \
 \
@@ -180,14 +180,17 @@ RUN export DEBIAN_FRONTEND=noninteractive \
             # Install 3rd party stuff
             && if [ "$version" != "9.5" ] && [ "$version" != "13" ]; then \
                 cd timescaledb \
-                && if [ "$version" = "11" ]; then \
-                    git checkout $TIMESCALEDB \
-                    && sed -i "s/3.11/3.10/" CMakeLists.txt; \
-                fi \
-                && BUILD_FORCE_REMOVE=true ./bootstrap -DREGRESS_CHECKS=OFF -DWARNINGS_AS_ERRORS=OFF \
-                    -DPG_CONFIG=/usr/lib/postgresql/$version/bin/pg_config \
-                    -DAPACHE_ONLY=$TIMESCALEDB_APACHE_ONLY -DSEND_TELEMETRY_DEFAULT=NO \
-                && make -C build install \
+                && for v in $TIMESCALEDB_LEGACY $TIMESCALEDB; do \
+                    if [ "$v" = "$TIMESCALEDB_LEGACY" ] || [ ${version%.*} -ge 11 ]; then \
+                        git checkout $v \
+                        && sed -i "s/VERSION 3.11/VERSION 3.10/" CMakeLists.txt \
+                        && BUILD_FORCE_REMOVE=true ./bootstrap -DREGRESS_CHECKS=OFF -DWARNINGS_AS_ERRORS=OFF \
+                            -DPG_CONFIG=/usr/lib/postgresql/$version/bin/pg_config \
+                            -DAPACHE_ONLY=$TIMESCALEDB_APACHE_ONLY -DSEND_TELEMETRY_DEFAULT=NO \
+                        && make -C build install \
+                        && git reset --hard; \
+                    fi; \
+                done \
                 && strip /usr/lib/postgresql/$version/lib/timescaledb*.so \
                 && cd ..; \
             fi \

--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -1,5 +1,5 @@
 ARG PGVERSION=13
-ARG TIMESCALEDB=1.7.4
+ARG TIMESCALEDB=2.0.0
 ARG TIMESCALEDB_LEGACY=1.7.4
 ARG DEMO=false
 ARG COMPRESS=false
@@ -182,8 +182,11 @@ RUN export DEBIAN_FRONTEND=noninteractive \
             # Install 3rd party stuff
             && if [ "$version" != "9.5" ] && [ "$version" != "13" ]; then \
                 cd timescaledb \
-                && if [ "$version" = "11" ]; then git checkout $TIMESCALEDB; fi \
-                && BUILD_FORCE_REMOVE=true ./bootstrap -DREGRESS_CHECKS=OFF \
+                && if [ "$version" = "11" ]; then \
+                    git checkout $TIMESCALEDB \
+                    && sed -i "s/3.11/3.10/" CMakeLists.txt; \
+                fi \
+                && BUILD_FORCE_REMOVE=true ./bootstrap -DREGRESS_CHECKS=OFF -DWARNINGS_AS_ERRORS=OFF \
                     -DPG_CONFIG=/usr/lib/postgresql/$version/bin/pg_config \
                     -DAPACHE_ONLY=$TIMESCALEDB_APACHE_ONLY -DSEND_TELEMETRY_DEFAULT=NO \
                 && make -C build install \

--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -28,22 +28,20 @@ RUN export DEBIAN_FRONTEND=noninteractive \
                 | tar xz -C /bin --strip=1 --wildcards --no-anchored etcdctl etcd; \
     fi \
 \
-    # Prepare find expression for ADDITIONAL_LOCALES
-    && for loc in $ADDITIONAL_LOCALES; do \
-        ADDITIONAL_LOCALE_FIND_EXPR="${ADDITIONAL_LOCALE_FIND_EXPR} ! -name ${loc}"; \
-    done \
     # Cleanup all locales but en_US.UTF-8 and optionally specified in ADDITIONAL_LOCALES arg
     && find /usr/share/i18n/charmaps/ -type f ! -name UTF-8.gz -delete \
-    && find /usr/share/i18n/locales/ -type f ! -name en_US ! -name en_GB ${ADDITIONAL_LOCALE_FIND_EXPR} ! -name i18n* ! -name iso14651_t1 ! -name iso14651_t1_common ! -name 'translit_*' -delete \
-    && echo 'en_US.UTF-8 UTF-8' > /usr/share/i18n/SUPPORTED \
+    # Prepare find expression for locales
+    && LOCALE_FIND_EXPR="-type f" \
+    && for loc in en_US en_GB $ADDITIONAL_LOCALES "i18n*" iso14651_t1 iso14651_t1_common "translit_*"; do \
+        LOCALE_FIND_EXPR="$LOCALE_FIND_EXPR ! -name $loc"; \
+    done \
+    && find /usr/share/i18n/locales/ $LOCALE_FIND_EXPR -delete \
 \
-    # Make sure we have a en_US.UTF-8 locale available
-    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
-\
-    # Make sure we have all additional locales available
-    && for loc in $ADDITIONAL_LOCALES; do \
-        echo "${loc}.UTF-8 UTF-8" >> /usr/share/i18n/SUPPORTED; \
-        localedef -i ${loc} -c -f UTF-8 -A /usr/share/locale/locale.alias ${loc}.UTF-8; \
+    # Make sure we have the en_US.UTF-8 and all additional locales available
+    && truncate --size 0 /usr/share/i18n/SUPPORTED \
+    && for loc in en_US $ADDITIONAL_LOCALES; do \
+        echo "$loc.UTF-8 UTF-8" >> /usr/share/i18n/SUPPORTED \
+        && localedef -i $loc -c -f UTF-8 -A /usr/share/locale/locale.alias $loc.UTF-8; \
     done \
 \
     # Add PGDG repositories


### PR DESCRIPTION
1. Fix build broken by postgis 3.1 release
   - use postgis 3.1 as main version
   - use postgis 3.0 as legacy version (postgres 9.5)
   - fix relinking code to support legacy postgis and optimize it to support relinking between all major versions, not only the current one.
2.  Bump version of timescaledb to 2.0
    - change cmake requirement from 3.11 to 3.11 in CMakeLists.txt. The old version available in ubuntu 18.04 perfectly works.
    - call bootstrap with -DWARNINGS_AS_ERRORS=OFF
    - 9.6 and 10 will continue using 1.7.4, therefore optimized relinking code in the commit updating postgis becomes very handy.
3. A bit unrelated, but since this PR already does a lot of housekeeping, optimize the code defining/cleaning locales in order to reduce the number of repetitions.

Close: #528, #529, #534, #533