### PR TITLE
Set AWS_REGION whenever USE_WALG_BACKUP is set to true

### DIFF
--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -719,7 +719,7 @@ def write_wale_environment(placeholders, prefix, overwrite):
             elif not wale_endpoint:
                 wale_endpoint = aws_endpoint.replace('://', '+path://')
             wale.update(WALE_S3_ENDPOINT=wale_endpoint, AWS_ENDPOINT=aws_endpoint, WALG_DISABLE_S3_SSE='true')
-            if wale.get('USE_WALG_BACKUP') and wale.get('USE_WALG_BACKUP') == 'true':
+            if aws_region and wale.get('USE_WALG_BACKUP') == 'true':
                 wale['AWS_REGION'] = aws_region
         elif not aws_region:
             # try to determine region from the endpoint or bucket name

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -719,6 +719,8 @@ def write_wale_environment(placeholders, prefix, overwrite):
             elif not wale_endpoint:
                 wale_endpoint = aws_endpoint.replace('://', '+path://')
             wale.update(WALE_S3_ENDPOINT=wale_endpoint, AWS_ENDPOINT=aws_endpoint, WALG_DISABLE_S3_SSE='true')
+            if wale.get('USE_WALG_BACKUP') and wale.get('USE_WALG_BACKUP') == 'true':
+                wale['AWS_REGION'] = aws_region
         elif not aws_region:
             # try to determine region from the endpoint or bucket name
             name = wale.get('WAL_S3_BUCKET') or wale.get('WALE_S3_PREFIX')


### PR DESCRIPTION
Since wal-g supports having both AWS_ENDPOINT (or WALE_S3_ENDPOINT) and AWS_REGION and that we cannot determine region from endpoint in the event of an onpremise deployment, this PR allows setting AWS_REGION even if AWS_ENDPOINT (or WALE_S3_ENDPOINT) is specified.

This way using an onpremise deploy with a custom region (http://someminioinstance:9000/ and my-place, ie) or using an endpoint that does not match the regex engine (https://somebucket.s3.nl-ams.scw.cloud, ie)