### PR TITLE
Fix bug with major upgrade after clone

### DIFF
--- a/postgres-appliance/major_upgrade/pg_upgrade.py
+++ b/postgres-appliance/major_upgrade/pg_upgrade.py
@@ -210,6 +210,9 @@ class _PostgresqlUpgrade(Postgresql):
 
         self.set_bin_dir(version)
 
+        # shared_preload_libraries for the old cluster, cleaned from incompatible/missing libs
+        old_shared_preload_libraries = self.config.get('parameters').get('shared_preload_libraries')
+
         # restore original values of archive_mode and shared_preload_libraries
         if getattr(self, '_old_config_values', None):
             for name, value in self._old_config_values.items():
@@ -218,6 +221,7 @@ class _PostgresqlUpgrade(Postgresql):
                 else:
                     self.config.get('parameters')[name] = value
 
+        # for the new version we maybe need to add some libs to the shared_preload_libraries
         shared_preload_libraries = self.config.get('parameters').get('shared_preload_libraries')
         if shared_preload_libraries:
             self._old_shared_preload_libraries = self.config.get('parameters')['shared_preload_libraries'] =\
@@ -238,8 +242,8 @@ class _PostgresqlUpgrade(Postgresql):
         self.config._postgresql_conf = old_postgresql_conf
         self._version_file = old_version_file
 
-        if shared_preload_libraries:
-            self.config.get('parameters')['shared_preload_libraries'] = shared_preload_libraries
+        if old_shared_preload_libraries:
+            self.config.get('parameters')['shared_preload_libraries'] = old_shared_preload_libraries
             self.no_bg_mon()
         self.configure_server_parameters()
         return True

--- a/postgres-appliance/tests/docker-compose.yml
+++ b/postgres-appliance/tests/docker-compose.yml
@@ -38,6 +38,7 @@ services:
             ETCDCTL_ENDPOINTS: http://etcd:2379
             ETCD_HOST: "etcd:2379"
             SCOPE: demo
+            ENABLE_PG_MON: 'true'
             SPILO_CONFIGURATION: |
               bootstrap:
                 dcs:


### PR DESCRIPTION
When working on the code removing bg_mon from shared_preload_libraries before executing pg_upgrade a little bug was introduced. Specifically, shared_preload_libraries for the old version was overwritten by the value taken from the new version. As a result, the old cluster was failing to start due to missing (not existing) libraries and upgrade was failing.

This commit is fixing the wrong behavior and improves tests to catch similar issues in the future.