### PR TITLE
Follow symlink for certificate renewal check

### DIFF
--- a/postgres-appliance/scripts/test_reload_ssl.sh
+++ b/postgres-appliance/scripts/test_reload_ssl.sh
@@ -28,7 +28,7 @@ has_changed() {
         return 1
     fi
     local mtime now elapsed_sec
-    mtime=$(stat -c '%Y' "$path")
+    mtime=$(stat -Lc '%Y' "$path")
     now=$(date +%s)
     elapsed_sec=$(( now - 1 - mtime ))
     if [[ $elapsed_sec -gt $test_interval_sec ]]; then


### PR DESCRIPTION
Particularly kubernetes is fond of having a symlink when mounting from a secret or config-map. This is a very common pattern with for example certmanager.
The `-L` flag tells stat to follow symlinks.

A typical file structure could look like this
```
postgres@gitlab-postgresql-cluster-0:~$ ls -l /tls/
total 0
lrwxrwxrwx 1 root root 13 Feb  2 08:24 ca.crt -> ..data/ca.crt
lrwxrwxrwx 1 root root 14 Feb  2 08:24 tls.crt -> ..data/tls.crt
lrwxrwxrwx 1 root root 14 Feb  2 08:24 tls.key -> ..data/tls.key
postgres@gitlab-postgresql-cluster-0:~$ ls -l /tls/..data
lrwxrwxrwx 1 root postgres 31 Feb 28 02:15 /tls/..data -> ..2021_02_28_02_15_21.040592773
postgres@gitlab-postgresql-cluster-0:~$ ls -l /tls/..data/
total 12
-rw-r----- 1 root postgres 1922 Feb 28 02:15 ca.crt
-rw-r----- 1 root postgres 3646 Feb 28 02:15 tls.crt
-rw-r----- 1 root postgres 1675 Feb 28 02:15 tls.key
```

Without the `-L` flag stat would show "Feb  2 08:24" from the symlink instead of "Feb 28 02:15" from the updated certificate. This in essence makes the cert check useless for any configuration where the cert is mounted as a kubernetes secret or configMap. As far as I can see at least.