### PR TITLE
Update postgres_backup.sh usage

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v1

--- a/postgres-appliance/scripts/postgres_backup.sh
+++ b/postgres-appliance/scripts/postgres_backup.sh
@@ -5,7 +5,7 @@ function log
     echo "$(date "+%Y-%m-%d %H:%M:%S.%3N") - $0 - $*"
 }
 
-[[ -z $1 ]] && echo "Usage: $0 PGDATA <DAYS_TO_RETAIN>" && exit 1
+[[ -z $1 ]] && echo "Usage: $0 PGDATA" && exit 1
 
 log "I was called as: $0 $*"
 


### PR DESCRIPTION
Minor update to the usage string in the postgres_backup.sh script.
In this [commit](https://github.com/zalando/spilo/commit/84668553b9cda6ba9da199ff3b3fe9fd89cf5aec#diff-12f469d988840b9eb6a93e31e87d9160d606abcdca4e47d6c9224e3df86335f0R14) the way that `DAYS_TO_RETAIN` is set was changed from command line argument to reading from the env var `BACKUP_NUM_TO_RETAIN`.
However, the usage string for the script was not updated to reflect the change, this commit fixes that.