### PR TITLE
Add backend_type column to postgres_log if it is missing on postgres 13

### DIFF
--- a/postgres-appliance/major_upgrade/pg_upgrade.py
+++ b/postgres-appliance/major_upgrade/pg_upgrade.py
@@ -101,9 +101,7 @@ class _PostgresqlUpgrade(Postgresql):
                 for ext in ('pg_stat_kcache', 'pg_stat_statements') + self._INCOMPATIBLE_EXTENSIONS:
                     logger.info('Executing "DROP EXTENSION IF EXISTS %s" in the database="%s"', ext, d)
                     cur.execute("DROP EXTENSION IF EXISTS {0}".format(ext))
-                if d[0] == 'postgres':
-                    logger.info('Executing "DROP TABLE postgres_log CASCADE" in the database=postgres')
-                    cur.execute('DROP TABLE IF EXISTS public.postgres_log CASCADE')
+
                 cur.execute("SELECT oid::regclass FROM pg_catalog.pg_class WHERE relpersistence = 'u'")
                 for unlogged in cur.fetchall():
                     logger.info('Truncating unlogged table %s', unlogged[0])

--- a/postgres-appliance/scripts/post_init.sh
+++ b/postgres-appliance/scripts/post_init.sh
@@ -107,11 +107,13 @@ CREATE TABLE IF NOT EXISTS public.postgres_log (
     query text,
     query_pos integer,
     location text,
-    application_name text,"
-if [ "$PGVER" -ge 13 ]; then echo "    backend_type text,"; fi
-echo "    CONSTRAINT postgres_log_check CHECK (false) NO INHERIT
+    application_name text,
+    CONSTRAINT postgres_log_check CHECK (false) NO INHERIT
 );
 GRANT SELECT ON public.postgres_log TO admin;"
+if [ "$PGVER" -ge 13 ]; then
+    echo "ALTER TABLE public.postgres_log ADD COLUMN IF NOT EXISTS backend_type text;"
+fi
 
 # Sunday could be 0 or 7 depending on the format, we just create both
 for i in $(seq 0 7); do


### PR DESCRIPTION
Due to the bug in the upgrade script postgres_log table wasn't dropped before pg_upgrade. As a result it wasn't recreated with the new structure.
In order to fix it, the post_init.sh running against Postgres 13 script will always try to add a column with NOT EXISTS.

At the same time we simplify the upgrade script. We don't need to drop the postgres_log foreign table before the upgrade.