### PR TITLE
Make it possible to run cron without a root

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -13,12 +13,14 @@ ARG ADDITIONAL_LOCALES=
 RUN export DEBIAN_FRONTEND=noninteractive \
     && echo 'APT::Install-Recommends "0";\nAPT::Install-Suggests "0";' > /etc/apt/apt.conf.d/01norecommend \
     && apt-get update \
-    && apt-get install -y curl ca-certificates less locales jq vim-tiny gnupg1 cron runit dumb-init libcap2-bin rsync \
+    && apt-get install -y curl ca-certificates less locales jq vim-tiny gnupg1 cron runit dumb-init libcap2-bin rsync sysstat \
     && ln -s chpst /usr/bin/envdir \
-    # Make it possible to use the following utilities without root
+    # Make it possible to use the following utilities without root (if container runs without "no-new-privileges:true")
     && setcap 'cap_sys_nice+ep' /usr/bin/chrt \
     && setcap 'cap_sys_nice+ep' /usr/bin/renice \
-    && chmod u+s /usr/sbin/cron \
+    # Disable unwanted cron jobs
+    && rm -fr /etc/cron.??* \
+    && truncate --size 0 /etc/crontab \
 \
     && if [ "$DEMO" != "true" ]; then \
         # Required for wal-e
@@ -64,7 +66,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
             /usr/share/locale/??_?? \
     && find /var/log -type f -exec truncate --size 0 {} \;
 
-COPY dependencies/debs dependencies/src /builddeps/
+COPY cron_unprivileged.c dependencies/debs dependencies/src /builddeps/
 
 ARG PGVERSION
 ARG TIMESCALEDB
@@ -141,7 +143,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && sed -i 's/^\(bool  show_.* =\) true;/\1 false;/' set_user/compatibility.h \
     && git clone https://github.com/timescale/timescaledb.git \
 \
-    && apt-get install -y postgresql-common libevent-2.1 libevent-pthreads-2.1 sysstat brotli libbrotli1 python3.6 python3-psycopg2 \
+    && apt-get install -y postgresql-common libevent-2.1 libevent-pthreads-2.1 brotli libbrotli1 python3.6 python3-psycopg2 \
 \
     # forbid creation of a main cluster when package is installed
     && sed -ri 's/#(create_main_cluster) .*$/\1 = false/' /etc/postgresql-common/createcluster.conf \
@@ -266,6 +268,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
             done; \
         done; \
     done \
+\
+    # make it possible for cron to work without root
+    && gcc -s -shared -fPIC -o /usr/local/lib/cron_unprivileged.so cron_unprivileged.c \
 \
     # Remove unnecessary packages
     && apt-get purge -y ${BUILD_PACKAGES} postgresql postgresql-server-dev-* libpq-dev=* libmagic1 bsdmainutils \

--- a/postgres-appliance/cron_unprivileged.c
+++ b/postgres-appliance/cron_unprivileged.c
@@ -1,0 +1,12 @@
+#include <sys/types.h>
+
+int seteuid(uid_t euid)
+{
+	return 0;
+}
+
+int initgroups(const char *user, gid_t group)
+{
+	return 0;
+}
+

--- a/postgres-appliance/runit/cron/run
+++ b/postgres-appliance/runit/cron/run
@@ -1,4 +1,8 @@
 #!/bin/sh -e
 
+if [ "$(id -u)" -ne 0 ]; then
+    LD_PRELOAD=/usr/local/lib/cron_unprivileged.so
+fi
+
 exec 2>&1
-exec env -i /usr/sbin/cron -f
+exec env -i LD_PRELOAD=$LD_PRELOAD /usr/sbin/cron -f

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -833,16 +833,16 @@ def write_crontab(placeholders, overwrite):
     lines = ['PATH={PATH}'.format(**placeholders)]
     root_lines = []
 
-    sys_nice_set = no_new_privs = None
+    sys_nice_is_set = no_new_privs = None
     with open('/proc/self/status') as f:
         for line in f:
             if line.startswith('NoNewPrivs:'):
                 no_new_privs = bool(int(line[12:]))
             elif line.startswith('CapBnd:'):
                 sys_nice = 0x800000
-                sys_nice_set = int(line[8:], 16) & sys_nice == sys_nice
+                sys_nice_is_set = int(line[8:], 16) & sys_nice == sys_nice
 
-    if sys_nice_set:
+    if sys_nice_is_set:
         renice = '*/5 * * * * bash /scripts/renice.sh'
         if not no_new_privs:
             lines += [renice]

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -833,18 +833,26 @@ def write_crontab(placeholders, overwrite):
     lines = ['PATH={PATH}'.format(**placeholders)]
     root_lines = []
 
+    sys_nice_set = no_new_privs = None
     with open('/proc/self/status') as f:
         for line in f:
-            if line.startswith('CapBnd:'):
+            if line.startswith('NoNewPrivs:'):
+                no_new_privs = bool(int(line[12:]))
+            elif line.startswith('CapBnd:'):
                 sys_nice = 0x800000
-                if int(line[8:], 16) & sys_nice == sys_nice:
-                    lines += ['*/5 * * * * bash /scripts/renice.sh']
-                    if os.getuid() == 0:
-                        root_lines = lines[:]
-                        lines.pop(1)
-                else:
-                    logging.info('Skipping creation of renice cron job due to lack of SYS_NICE capability')
-                break
+                sys_nice_set = int(line[8:], 16) & sys_nice == sys_nice
+
+    if sys_nice_set:
+        renice = '*/5 * * * * bash /scripts/renice.sh'
+        if not no_new_privs:
+            lines += [renice]
+        elif os.getuid() == 0:
+            root_lines = [lines[0], renice]
+        else:
+            logging.info('Skipping creation of renice cron job due to running as not root '
+                         'and with "no-new-privileges:true" (allowPrivilegeEscalation=false on K8s)')
+    else:
+        logging.info('Skipping creation of renice cron job due to lack of SYS_NICE capability')
 
     if placeholders.get('SSL_TEST_RELOAD'):
         env = ' '.join('{0}="{1}"'.format(n, placeholders[n]) for n in ('SSL_CA_FILE', 'SSL_CRL_FILE',


### PR DESCRIPTION
* Don't set suid bit on `/usr/sbin/cron` (even if it could be used there is no way to safely create the root cronjob, but it also means that the `sys_nice` capability which is set on `chrt` and `renice` could be used).
* Use `LD_PRELOAD` trick for hooking `seteuid()` and `initgroups()` functions when starting cron deamon without a root.
* Enhance scheduling (or not scheduling) the renice cronjob depending on the initial conditions (root, sys_nice, no-new-privileges).
* Disable unwanted cronjobs (`/etc/crontab`, `/etc/cron.{hourly,daily,...}`), they produce "scary" logs when cron is running without a root.

Close: https://github.com/zalando/spilo/issues/562