### PR TITLE
Update StatefulSet apiVersion in Kubernetes manifest

### DIFF
--- a/.github/workflows/kubernetes-test.yaml
+++ b/.github/workflows/kubernetes-test.yaml
@@ -1,0 +1,22 @@
+name: Kubernetes Installation Test
+
+on: 
+  pull_request:
+    paths:
+    - 'kubernetes/**'
+  push:
+    branches:
+    - master
+    paths:
+    - 'kubernetes/**'
+
+jobs:
+  kubernetes-installation-test:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Create Kind Cluster
+      uses: helm/kind-action@v1.1.0
+    - name: Install Spilo
+      run: kubectl apply -f kubernetes/spilo_kubernetes.yaml

--- a/kubernetes/spilo_kubernetes.yaml
+++ b/kubernetes/spilo_kubernetes.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: &cluster_name zalandodemo01
@@ -6,6 +6,10 @@ metadata:
     application: spilo
     spilo-cluster: *cluster_name
 spec:
+  selector:
+    matchLabels:
+      application: spilo
+      spilo-cluster: *cluster_name
   replicas: 3
   serviceName: *cluster_name
   template:
@@ -24,24 +28,24 @@ spec:
         iam.amazonaws.com/role: app-spilo
         # forces the scheduler not to put pods on the same node.
         scheduler.alpha.kubernetes.io/affinity: >
-            {
-                "podAntiAffinity": {
-                  "requiredDuringSchedulingIgnoredDuringExecution": [
-                    {
-                        "labelSelector": {
-                          "matchExpressions": [
-                            {
-                              "key": "spilo-cluster",
-                              "operator": "In",
-                              "values": ["zalandodemo01"]
-                            }
-                          ]
-                         },
-                         "topologyKey": "kubernetes.io/hostname"
-                    }
-                  ]
-                 }
+          {
+            "podAntiAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": [
+                {
+                  "labelSelector": {
+                    "matchExpressions": [
+                      {
+                        "key": "spilo-cluster",
+                        "operator": "In",
+                        "values": ["zalandodemo01"]
+                      }
+                    ]
+                  },
+                  "topologyKey": "kubernetes.io/hostname"
+                }
+              ]
             }
+          }
     spec:
       # service account that allows changing endpoints and assigning pod labels
       # in the given namespace: https://kubernetes.io/docs/user-guide/service-accounts/


### PR DESCRIPTION
- Update deprecated apps/v1beta1 API.
https://kubernetes.io/docs/reference/using-api/deprecation-guide/#statefulset-v116
- Add a simple test for installation on Kubernetes.
- Format affinity JSON.