### PR TITLE
Add support for WAL-E/WAL-G with custom PGPORT

### DIFF
--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -705,7 +705,7 @@ def write_wale_environment(placeholders, prefix, overwrite):
                   'WALG_SENTINEL_USER_DATA', 'WALG_PREVENT_WAL_OVERWRITE', 'WALG_S3_CA_CERT_FILE']
 
     wale = defaultdict(lambda: '')
-    for name in ['PGVERSION', 'WALE_ENV_DIR', 'SCOPE', 'WAL_BUCKET_SCOPE_PREFIX', 'WAL_BUCKET_SCOPE_SUFFIX',
+    for name in ['PGVERSION', 'PGPORT', 'WALE_ENV_DIR', 'SCOPE', 'WAL_BUCKET_SCOPE_PREFIX', 'WAL_BUCKET_SCOPE_SUFFIX',
                  'WAL_S3_BUCKET', 'WAL_GCS_BUCKET', 'WAL_GS_BUCKET', 'WAL_SWIFT_BUCKET', 'BACKUP_NUM_TO_RETAIN',
                  'ENABLE_WAL_PATH_COMPAT'] + s3_names + swift_names + gs_names + walg_names + azure_names + ssh_names:
         wale[name] = placeholders.get(prefix + name, '')
@@ -771,7 +771,7 @@ def write_wale_environment(placeholders, prefix, overwrite):
         os.makedirs(wale['WALE_ENV_DIR'])
 
     wale['WALE_LOG_DESTINATION'] = 'stderr'
-    for name in write_envdir_names + ['WALE_LOG_DESTINATION'] + ([] if prefix else ['BACKUP_NUM_TO_RETAIN']):
+    for name in write_envdir_names + ['WALE_LOG_DESTINATION', 'PGPORT'] + ([] if prefix else ['BACKUP_NUM_TO_RETAIN']):
         if wale.get(name):
             path = os.path.join(wale['WALE_ENV_DIR'], name)
             write_file(wale[name], path, overwrite)


### PR DESCRIPTION
Fixes issue #571.

The comment: https://github.com/zalando/spilo/issues/571#issuecomment-806790634 was not sufficient as `PGPORT` must also be placed in `write_envidir_names` or as implemented here.

Note that the current implementation adds  the `PGPORT` file to the WAL-E/WAL-G configuration files indiscriminately, even if it isn't necessary for default port use cases. This does not cause any problems but it is redundant.