### PR TITLE
Fix wrong envvar name for AZURE_STORAGE_ACCESS_KEY

### DIFF
--- a/ENVIRONMENT.rst
+++ b/ENVIRONMENT.rst
@@ -67,7 +67,7 @@ Environment Configuration Settings
 - **SSH_USERNAME**: (optional) the username for WAL backups.
 - **SSH_PRIVATE_KEY_PATH**: (optional) the path to the private key used for WAL backups.
 - **AZURE_STORAGE_ACCOUNT**:(optional) the azure storage account to use for WAL backups.
-- **AZURE_STORAGE_ACCOUNT_ACCESS_KEY**:(optional) the access key for the azure storage account used for WAL backups.
+- **AZURE_STORAGE_ACCESS_KEY**:(optional) the access key for the azure storage account used for WAL backups.
 - **CALLBACK_SCRIPT**: the callback script to run on various cluster actions (on start, on stop, on restart, on role change). The script will receive the cluster name, connection string and the current action. See `Patroni <http://patroni.readthedocs.io/en/latest/SETTINGS.html?highlight=callback#postgresql>`__ documentation for details.
 - **LOG_S3_BUCKET**: path to the S3 bucket used for PostgreSQL daily log files (i.e. s3://foobar). Spilo will add /spilo/scope/pg_daily_logs to that path. Logs are shipped if this variable is set.
 - **LOG_SHIP_SCHEDULE**: cron schedule for shipping compressed logs from ``pg_log`` (if this feature is enabled, '00 02 * * *' by default)


### PR DESCRIPTION
When trying to run WAL backup with Azure storage account, I got the following error message:

```
ERROR: 2021/07/12 17:47:42.051175 failed to configure folder: Azure error : AZURE_STORAGE_ACCESS_KEY setting is not set: Credential error
```

After specifying `AZURE_STORAGE_ACCESS_KEY` (instead of `AZURE_STORAGE_ACCOUNT_ACCESS_KEY`), it worked fine.

Also, regarding the [wal-g documentation](https://github.com/wal-g/wal-g/blob/908e18f8b1f3ea319130b69508a10c5dbf8d7b01/docs/STORAGES.md#azure), the envvar for Azure storage access key is `AZURE_STORAGE_ACCESS_KEY`.

