### PR TITLE
#585 certificate rotation based on file hash, not modified time

### DIFF
--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -857,7 +857,8 @@ def write_crontab(placeholders, overwrite):
     if placeholders.get('SSL_TEST_RELOAD'):
         env = ' '.join('{0}="{1}"'.format(n, placeholders[n]) for n in ('PGDATA', 'SSL_CA_FILE', 'SSL_CRL_FILE',
                        'SSL_CERTIFICATE_FILE', 'SSL_PRIVATE_KEY_FILE') if placeholders.get(n))
-        lines += ['*/5 * * * * {0} /scripts/test_reload_ssl.sh /tmp'.format(env)]
+        hash_dir = os.path.join(placeholders['RW_DIR'], 'tmp')
+        lines += ['*/5 * * * * {0} /scripts/test_reload_ssl.sh {1}'.format(env, hash_dir)]
 
     if bool(placeholders.get('USE_WALE')):
         lines += [('{BACKUP_SCHEDULE} envdir "{WALE_ENV_DIR}" /scripts/postgres_backup.sh' +

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -855,9 +855,9 @@ def write_crontab(placeholders, overwrite):
         logging.info('Skipping creation of renice cron job due to lack of SYS_NICE capability')
 
     if placeholders.get('SSL_TEST_RELOAD'):
-        env = ' '.join('{0}="{1}"'.format(n, placeholders[n]) for n in ('SSL_CA_FILE', 'SSL_CRL_FILE',
+        env = ' '.join('{0}="{1}"'.format(n, placeholders[n]) for n in ('PGDATA', 'SSL_CA_FILE', 'SSL_CRL_FILE',
                        'SSL_CERTIFICATE_FILE', 'SSL_PRIVATE_KEY_FILE') if placeholders.get(n))
-        lines += ['*/5 * * * * {0} /scripts/test_reload_ssl.sh 5'.format(env)]
+        lines += ['*/5 * * * * {0} /scripts/test_reload_ssl.sh /tmp'.format(env)]
 
     if bool(placeholders.get('USE_WALE')):
         lines += [('{BACKUP_SCHEDULE} envdir "{WALE_ENV_DIR}" /scripts/postgres_backup.sh' +

--- a/postgres-appliance/scripts/test_reload_ssl.sh
+++ b/postgres-appliance/scripts/test_reload_ssl.sh
@@ -28,6 +28,8 @@ has_changed() {
     local env=$1
     local src_path=${!1:-}
     local hash_path="$last_hash_dir/${env}.hash"
+    local live_hash
+    local last_hash
 
     if [[ -z "$src_path" ]]; then
         log "env=$env: environment is not set"
@@ -42,9 +44,10 @@ has_changed() {
         return 0
     fi
 
-    local live_hash=$($hash_cmd "$src_path")
-    local last_hash=$(cat "$hash_path")
-    if [[ $live_hash = $last_hash ]]; then
+    live_hash=$($hash_cmd "$src_path")
+    last_hash=$(cat "$hash_path")
+
+    if [[ $live_hash = "$last_hash" ]]; then
         log "env=$env path=$src_path live_hash=$live_hash: no changes detected"
         return 1
     fi

--- a/postgres-appliance/scripts/test_reload_ssl.sh
+++ b/postgres-appliance/scripts/test_reload_ssl.sh
@@ -1,14 +1,22 @@
 #!/bin/bash
 #
-# This script is being called every TEST_INTERVAL_MINUTES to check if the
-# spilo or postgres configuration need to be reloaded.
+# This script is called to check if the spilo or postgres configuration need to
+# be reloaded due to changes in TLS files.
 #
-# Usage: test_reload_ssl.sh <TEST_INTERVAL_MINUTES>
+# Usage: test_reload_ssl.sh <STORED_HASH_DIRECTORY>
 set -euo pipefail
 
-# How often this script is being called
-test_interval_min=$1
-test_interval_sec=$((test_interval_min * 60))
+# Directory where hashes for each SSL file are stored
+last_hash_dir=$1
+
+# Redirect output to a log file
+# exec >$last_hash_dir/test_reload_ssl.log 2>&1
+# NOW="$(date)"
+# LOGNAME="$last_hash_dir/test_reload_ssl.log."${NOW}
+# exec > "$LOGNAME" 2>&1
+
+# The hash command to use
+hash_cmd="sha256sum"
 
 ## Functions ##
 
@@ -18,25 +26,50 @@ log() {
 
 has_changed() {
     local env=$1
-    local path=${!1:-}
-    if [[ -z "$path" ]]; then
+    local src_path=${!1:-}
+    local hash_path="$last_hash_dir/${env}.hash"
+
+    if [[ -z "$src_path" ]]; then
         log "env=$env: environment is not set"
         return 1
     fi
-    if [[ ! -e "$path" ]]; then
-        log "env=$env path=$path: does not exist"
+    if [[ ! -e "$src_path" ]]; then
+        log "env=$env src_path=$src_path: does not exist"
         return 1
     fi
-    local mtime now elapsed_sec
-    mtime=$(stat -Lc '%Y' "$path")
-    now=$(date +%s)
-    elapsed_sec=$(( now - 1 - mtime ))
-    if [[ $elapsed_sec -gt $test_interval_sec ]]; then
-        log "env=$env path=$path elapsec_sec=$elapsed_sec: no changes detected"
+    if [[ ! -e "$hash_path" ]]; then
+        log "env=$env hash_path=$hash_path: does not exist yet"
+        return 0
+    fi
+
+    local live_hash=$($hash_cmd "$src_path")
+    local last_hash=$(cat "$hash_path")
+    if [[ $live_hash = $last_hash ]]; then
+        log "env=$env path=$src_path live_hash=$live_hash: no changes detected"
         return 1
     fi
-    log "env=$env path=$path elapsec_sec=$elapsed_sec: found changes"
+    log "env=$env path=$src_path live_hash=$live_hash last_hash=$last_hash: found changes"
     return 0
+}
+
+write_hash() {
+    local env=$1
+    local src_path=${!1:-}
+    local hash_path="$last_hash_dir/${env}.hash"
+
+    if [[ ! -e "$src_path" ]]; then
+        log "env=$env src_path=$src_path: does not exist; skipped writing hash"
+        return 0
+    fi
+
+    $hash_cmd "$src_path" > "$hash_path"
+}
+
+write_hashes() {
+    write_hash SSL_CA_FILE
+    write_hash SSL_CRL_FILE
+    write_hash SSL_CERTIFICATE_FILE
+    write_hash SSL_PRIVATE_KEY_FILE
 }
 
 ## Main ##
@@ -49,4 +82,5 @@ if
 then
     log "Reloading due to detected changes"
     pg_ctl reload
+    write_hashes
 fi


### PR DESCRIPTION
Updating the certificate reload scripts to be based on @bchrobots [script change](https://github.com/zalando/spilo/issues/585#issuecomment-856846628). 

I have tested this and can verify that it works.