### PR TITLE
Add timescaledb 2.4.0

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -1,7 +1,6 @@
 ARG BASE_IMAGE=ubuntu:18.04
 ARG PGVERSION=13
-ARG TIMESCALEDB=2.3.1
-ARG TIMESCALEDB_LEGACY=1.7.5
+ARG TIMESCALEDB="1.7.5 2.3.1 2.4.0"
 ARG DEMO=false
 ARG COMPRESS=false
 
@@ -70,7 +69,6 @@ COPY cron_unprivileged.c dependencies/debs dependencies/src /builddeps/
 
 ARG PGVERSION
 ARG TIMESCALEDB
-ARG TIMESCALEDB_LEGACY
 ARG TIMESCALEDB_APACHE_ONLY=true
 ARG DEMO
 ARG COMPRESS
@@ -183,23 +181,20 @@ RUN export DEBIAN_FRONTEND=noninteractive \
                     postgresql-${version}-pg-stat-kcache $EXTRAS \
 \
             # Install 3rd party stuff
-            && if [ "$version" != "9.5" ]; then \
-                cd timescaledb \
-                && for v in $TIMESCALEDB_LEGACY $TIMESCALEDB; do \
-                    if [ "$v" = "$TIMESCALEDB_LEGACY" ] || [ ${version%.*} -ge 11 ]; then \
-                        git checkout $v \
-                        && sed -i "s/VERSION 3.11/VERSION 3.10/" CMakeLists.txt \
-                        && if BUILD_FORCE_REMOVE=true ./bootstrap -DREGRESS_CHECKS=OFF -DWARNINGS_AS_ERRORS=OFF \
-                            -DPG_CONFIG=/usr/lib/postgresql/$version/bin/pg_config \
-                            -DAPACHE_ONLY=$TIMESCALEDB_APACHE_ONLY -DSEND_TELEMETRY_DEFAULT=NO; then \
-                                make -C build install \
-                                && strip /usr/lib/postgresql/$version/lib/timescaledb*.so; \
-                        fi; \
-                    fi \
-                    && git reset --hard; \
-                done \
-                && cd ..; \
-            fi \
+            && cd timescaledb \
+            && for v in $TIMESCALEDB; do \
+                git checkout $v \
+                && sed -i "s/VERSION 3.11/VERSION 3.10/" CMakeLists.txt \
+                && if BUILD_FORCE_REMOVE=true ./bootstrap -DREGRESS_CHECKS=OFF -DWARNINGS_AS_ERRORS=OFF \
+                    -DTAP_CHECKS=OFF -DPG_CONFIG=/usr/lib/postgresql/$version/bin/pg_config \
+                    -DAPACHE_ONLY=$TIMESCALEDB_APACHE_ONLY -DSEND_TELEMETRY_DEFAULT=NO; then \
+                        make -C build install \
+                        && strip /usr/lib/postgresql/$version/lib/timescaledb*.so; \
+                fi \
+                && git reset --hard \
+                && git clean -f -d; \
+            done \
+            && cd .. \
 \
             && if [ "$DEMO" != "true" ]; then \
                 if [ ${version%.*} -lt 11 ]; then \
@@ -454,7 +449,6 @@ LABEL maintainer="Alexander Kukushkin <alexander.kukushkin@zalando.de>"
 
 ARG PGVERSION
 ARG TIMESCALEDB
-ARG TIMESCALEDB_LEGACY
 ARG DEMO
 ARG COMPRESS
 
@@ -465,7 +459,6 @@ ENV LC_ALL=en_US.utf-8 \
     PGHOME=/home/postgres \
     RW_DIR=/run \
     TIMESCALEDB=$TIMESCALEDB \
-    TIMESCALEDB_LEGACY=$TIMESCALEDB_LEGACY \
     DEMO=$DEMO
 
 ENV WALE_ENV_DIR=$RW_DIR/etc/wal-e.d/env \

--- a/postgres-appliance/runit/patroni/run
+++ b/postgres-appliance/runit/patroni/run
@@ -21,7 +21,7 @@ fi
 ulimit -c unlimited
 
 # Only small subset of environment variables is allowed. We don't want accidentally disclose sensitive information
-for E in $(printenv -0 | tr '\n' ' ' | sed 's/\x00/\n/g' | grep -vE '^(KUBERNETES_(SERVICE|PORT|ROLE)[_=]|((POD_(IP|NAMESPACE))|HOSTNAME|PATH|PGHOME|LC_ALL|TIMESCALEDB|TIMESCALEDB_LEGACY|ENABLE_PG_MON)=)' | sed 's/=.*//g'); do
+for E in $(printenv -0 | tr '\n' ' ' | sed 's/\x00/\n/g' | grep -vE '^(KUBERNETES_(SERVICE|PORT|ROLE)[_=]|((POD_(IP|NAMESPACE))|HOSTNAME|PATH|PGHOME|LC_ALL|ENABLE_PG_MON)=)' | sed 's/=.*//g'); do
     unset $E
 done
 

--- a/postgres-appliance/scripts/post_init.sh
+++ b/postgres-appliance/scripts/post_init.sh
@@ -137,9 +137,8 @@ while IFS= read -r db_name; do
     echo "\c ${db_name}"
     # In case if timescaledb binary is missing the first query fails with the error
     # ERROR:  could not access file "$libdir/timescaledb-$OLD_VERSION": No such file or directory
-    TIMESCALEDB_VERSION=$(echo -e "SELECT NULL;\nSELECT extversion FROM pg_catalog.pg_extension WHERE extname = 'timescaledb'" | psql -tAX -d "${db_name}" 2> /dev/null | tail -n 1)
-    if [ "x$TIMESCALEDB_VERSION" != "x" ] && [ "x$TIMESCALEDB_VERSION" != "x$TIMESCALEDB" ] \
-            && { [ "$PGVER" -ge 11 ] || [ "x$TIMESCALEDB_VERSION" != "x$TIMESCALEDB_LEGACY" ]; }; then
+    UPGRADE_TIMESCALEDB=$(echo -e "SELECT NULL;\nSELECT default_version != installed_version FROM pg_catalog.pg_available_extensions WHERE name = 'timescaledb'" | psql -tAX -d "${db_name}" 2> /dev/null | tail -n 1)
+    if [ "x$UPGRADE_TIMESCALEDB" = "xt" ]; then
         echo "ALTER EXTENSION timescaledb UPDATE;"
     fi
     UPGRADE_POSTGIS=$(echo -e "SELECT COUNT(*) FROM pg_catalog.pg_extension WHERE extname = 'postgis'" | psql -tAX -d "${db_name}" 2> /dev/null | tail -n 1)


### PR DESCRIPTION
* build all possible latest major versions of timescaledb for every major version of Postgres (sometimes they are required for major upgrade)
* change post_init.sh script to not rely on TIMESCALEDB* env variables for determining whether the timescaledb extension should be updated