### PR TITLE
Document SSL_CERTIFICATE and SSL_PRIVATE_KEY and add SSL_CA and SSL_C…

### DIFF
--- a/ENVIRONMENT.rst
+++ b/ENVIRONMENT.rst
@@ -31,6 +31,10 @@ Environment Configuration Settings
 - **SSL_CRL_FILE**: path to the SSL Certificate Revocation List file inside the container (by default: '')
 - **SSL_CERTIFICATE_FILE**: path to the SSL certificate file inside the container (by default PGHOME/server.crt), Spilo will generate one if not present.
 - **SSL_PRIVATE_KEY_FILE**: path to the SSL private key within the container (by default PGHOME/server.key), Spilo will generate one if not present
+- **SSL_CA**: content of the SSL CA certificate in the SSL_CA_FILE file (by default: '')
+- **SSL_CRL**: content of the SSL Certificate Revocation List in the SSL_CRL_FILE file (by default: '')
+- **SSL_CERTIFICATE**: content of the SSL certificate in the SSL_CERTIFICATE_FILE file (by default PGHOME/server.crt).
+- **SSL_PRIVATE_KEY**: content of the SSL private key in the SSL_PRIVATE_KEY_FILE file (by default PGHOME/server.key).
 - **SSL_TEST_RELOAD**: whenever to test for certificate rotation and reloading (by default True if SSL_PRIVATE_KEY_FILE has been set)
 - **WALE_BACKUP_THRESHOLD_MEGABYTES**: maximum size of the WAL segments accumulated after the base backup to consider WAL-E restore instead of pg_basebackup.
 - **WALE_BACKUP_THRESHOLD_PERCENTAGE**: maximum ratio (in percents) of the accumulated WAL files to the base backup to consider WAL-E restore instead of pg_basebackup.

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -112,7 +112,6 @@ def write_certificates(environment, overwrite):
         p = subprocess.Popen(openssl_cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         output, _ = p.communicate()
         logging.debug(output)
-        logging.info('Generating ssl certificate')
     if 'SSL_CA' in environment:
         logging.info('Generating ssl ca certificate')
         write_file(environment['SSL_CA'], environment['SSL_CA_FILE'], overwrite)

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -91,6 +91,16 @@ def write_certificates(environment, overwrite):
         logging.info('Writing custom ssl certificate')
         for k in ssl_keys:
             write_file(environment[k], environment[k + '_FILE'], overwrite)
+        if 'SSL_CA' in environment:
+            logging.info('Generating ssl ca certificate')
+            write_file(environment['SSL_CA'], environment['SSL_CA_FILE'], overwrite)
+        else:
+            logging.info('No CA certificate to generate')
+        if 'SSL_CRL' in environment:
+            logging.info('Generating ssl crl certificate')
+            write_file(environment['SSL_CRL'], environment['SSL_CRL_FILE'], overwrite)
+        else:
+            logging.info('No CRL certificate to generate')
     else:
         if os.path.exists(environment['SSL_PRIVATE_KEY_FILE']) and not overwrite:
             logging.warning('Private key already exists, not overwriting. (Use option --force if necessary)')
@@ -112,16 +122,6 @@ def write_certificates(environment, overwrite):
         p = subprocess.Popen(openssl_cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         output, _ = p.communicate()
         logging.debug(output)
-    if 'SSL_CA' in environment:
-        logging.info('Generating ssl ca certificate')
-        write_file(environment['SSL_CA'], environment['SSL_CA_FILE'], overwrite)
-    else:
-        logging.info('No ca certificate to generate')
-    if 'SSL_CRL' in environment:
-        logging.info('Generating ssl crl certificate')
-        write_file(environment['SSL_CRL'], environment['SSL_CRL_FILE'], overwrite)
-    else:
-        logging.info('No crl certificate to generate')
 
     os.chmod(environment['SSL_PRIVATE_KEY_FILE'], 0o600)
     adjust_owner(environment['SSL_PRIVATE_KEY_FILE'], gid=-1)

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -88,7 +88,7 @@ def write_certificates(environment, overwrite):
 
     ssl_keys = ['SSL_CERTIFICATE', 'SSL_PRIVATE_KEY']
     if set(ssl_keys) <= set(environment):
-        logging.info('Generating custom ssl certificate')
+        logging.info('Writing custom ssl certificate')
         for k in ssl_keys:
             write_file(environment[k], environment[k + '_FILE'], overwrite)
     else:

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -88,6 +88,7 @@ def write_certificates(environment, overwrite):
 
     ssl_keys = ['SSL_CERTIFICATE', 'SSL_PRIVATE_KEY']
     if set(ssl_keys) <= set(environment):
+        logging.info('Generating custom ssl certificate')
         for k in ssl_keys:
             write_file(environment[k], environment[k + '_FILE'], overwrite)
     else:
@@ -107,10 +108,21 @@ def write_certificates(environment, overwrite):
             '-out',
             environment['SSL_CERTIFICATE_FILE'],
         ]
-        logging.info('Generating ssl certificate')
+        logging.info('Autogenerating ssl certificate')
         p = subprocess.Popen(openssl_cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         output, _ = p.communicate()
         logging.debug(output)
+        logging.info('Generating ssl certificate')
+    if 'SSL_CA' in environment:
+        logging.info('Generating ssl ca certificate')
+        write_file(environment['SSL_CA'], environment['SSL_CA_FILE'], overwrite)
+    else:
+        logging.info('No ca certificate to generate')
+    if 'SSL_CRL' in environment:
+        logging.info('Generating ssl crl certificate')
+        write_file(environment['SSL_CRL'], environment['SSL_CRL_FILE'], overwrite)
+    else:
+        logging.info('No crl certificate to generate')
 
     os.chmod(environment['SSL_PRIVATE_KEY_FILE'], 0o600)
     adjust_owner(environment['SSL_PRIVATE_KEY_FILE'], gid=-1)


### PR DESCRIPTION
Currently, Spilo has two variables not documented:
* SSL_CERTIFICATE
* SSL_PRIVATE_KEY

you can use it to pass a custom certificate with a private key.
The problem is that there is no variable to pass the content of the CA certificate and let Spilo create it in SSL_CA_FILE path. For this reason, I added the following variable:
* SSL_CA

Alexander Kukushkin asked me on the slack channel to add the SSL_CRL variable as well.
Please review the PR and let me know for any issue.