### PR TITLE
Document SSL_CERTIFICATE and SSL_PRIVATE_KEY and add SSL_CA and SSL_C…

### DIFF
--- a/ENVIRONMENT.rst
+++ b/ENVIRONMENT.rst
@@ -31,6 +31,10 @@ Environment Configuration Settings
 - **SSL_CRL_FILE**: path to the SSL Certificate Revocation List file inside the container (by default: '')
 - **SSL_CERTIFICATE_FILE**: path to the SSL certificate file inside the container (by default PGHOME/server.crt), Spilo will generate one if not present.
 - **SSL_PRIVATE_KEY_FILE**: path to the SSL private key within the container (by default PGHOME/server.key), Spilo will generate one if not present
+- **SSL_CA**: content of the SSL CA certificate in the SSL_CA_FILE file (by default: '')
+- **SSL_CRL**: content of the SSL Certificate Revocation List in the SSL_CRL_FILE file (by default: '')
+- **SSL_CERTIFICATE**: content of the SSL certificate in the SSL_CERTIFICATE_FILE file (by default PGHOME/server.crt).
+- **SSL_PRIVATE_KEY**: content of the SSL private key in the SSL_PRIVATE_KEY_FILE file (by default PGHOME/server.key).
 - **SSL_TEST_RELOAD**: whenever to test for certificate rotation and reloading (by default True if SSL_PRIVATE_KEY_FILE has been set)
 - **WALE_BACKUP_THRESHOLD_MEGABYTES**: maximum size of the WAL segments accumulated after the base backup to consider WAL-E restore instead of pg_basebackup.
 - **WALE_BACKUP_THRESHOLD_PERCENTAGE**: maximum ratio (in percents) of the accumulated WAL files to the base backup to consider WAL-E restore instead of pg_basebackup.


### PR DESCRIPTION
Currently, Spilo has two variables not documented:

SSL_CERTIFICATE
SSL_PRIVATE_KEY
you can use it to pass a custom certificate with a private key.
The problem is that there is no variable to pass the content of the CA certificate and let Spilo create it in the SSL_CA_FILE path. For this reason, I added the following variable:

SSL_CA
Alexander Kukushkin asked me on the slack channel to add the SSL_CRL variable as well.
Please review the PR and let me know of any issues.