### PR TITLE
Add Patroni REST Api SSL certificates environment variables

### DIFF
--- a/ENVIRONMENT.rst
+++ b/ENVIRONMENT.rst
@@ -29,12 +29,18 @@ Environment Configuration Settings
 - **SCOPE**: cluster name, multiple Spilos belonging to the same cluster must have identical scope.
 - **SSL_CA_FILE**: path to the SSL CA certificate file inside the container (by default: '')
 - **SSL_CRL_FILE**: path to the SSL Certificate Revocation List file inside the container (by default: '')
-- **SSL_CERTIFICATE_FILE**: path to the SSL certificate file inside the container (by default PGHOME/server.crt), Spilo will generate one if not present.
-- **SSL_PRIVATE_KEY_FILE**: path to the SSL private key within the container (by default PGHOME/server.key), Spilo will generate one if not present
+- **SSL_CERTIFICATE_FILE**: path to the SSL certificate file inside the container (by default /run/certs/server.crt), Spilo will generate one if not present.
+- **SSL_PRIVATE_KEY_FILE**: path to the SSL private key within the container (by default /run/certs/server.key), Spilo will generate one if not present
 - **SSL_CA**: content of the SSL CA certificate in the SSL_CA_FILE file (by default: '')
 - **SSL_CRL**: content of the SSL Certificate Revocation List in the SSL_CRL_FILE file (by default: '')
-- **SSL_CERTIFICATE**: content of the SSL certificate in the SSL_CERTIFICATE_FILE file (by default PGHOME/server.crt).
-- **SSL_PRIVATE_KEY**: content of the SSL private key in the SSL_PRIVATE_KEY_FILE file (by default PGHOME/server.key).
+- **SSL_CERTIFICATE**: content of the SSL certificate in the SSL_CERTIFICATE_FILE file (by default /run/certs/server.crt).
+- **SSL_PRIVATE_KEY**: content of the SSL private key in the SSL_PRIVATE_KEY_FILE file (by default /run/certs/server.key).
+- **SSL_RESTAPI_CA_FILE**: path to the Patroni REST Api SSL CA certificate file inside the container (by default: '')
+- **SSL_RESTAPI_CERTIFICATE_FILE**: path to the Patroni REST Api SSL certificate file inside the container (by default /run/certs/restapi.crt), Spilo will generate one if not present.
+- **SSL_RESTAPI_PRIVATE_KEY_FILE**: path to the Patroni REST Api SSL private key within the container (by default /run/certs/restapi.key), Spilo will generate one if not present
+- **SSL_RESTAPI_CA**: content of the Patroni REST Api SSL CA certificate in the SSL_RESTAPI_CA_FILE file (by default: '')
+- **SSL_RESTAPI_CERTIFICATE**: content of the REST Api SSL certificate in the SSL_CERTIFICATE_FILE file (by default /run/certs/server.crt).
+- **SSL_RESTAPI_PRIVATE_KEY**: content of the REST Api SSL private key in the SSL_PRIVATE_KEY_FILE file (by default /run/certs/server.key).
 - **SSL_TEST_RELOAD**: whenever to test for certificate rotation and reloading (by default True if SSL_PRIVATE_KEY_FILE has been set)
 - **WALE_BACKUP_THRESHOLD_MEGABYTES**: maximum size of the WAL segments accumulated after the base backup to consider WAL-E restore instead of pg_basebackup.
 - **WALE_BACKUP_THRESHOLD_PERCENTAGE**: maximum ratio (in percents) of the accumulated WAL files to the base backup to consider WAL-E restore instead of pg_basebackup.

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -139,9 +139,6 @@ def write_restapi_certificates(environment, overwrite):
         for k in ssl_keys:
             write_file(environment[k], environment[k + '_FILE'], overwrite)
         if 'SSL_RESTAPI_CA' in environment:
-            if environment['SSL_RESTAPI_CA_FILE'] == '':
-                environment['SSL_RESTAPI_CA_FILE'] = os.path.join(environment['RW_DIR'], 'certs',
-                                                                  'rest-api-server-ca.crt')
             logging.info('Writing REST Api ssl ca certificate')
             write_file(environment['SSL_RESTAPI_CA'], environment['SSL_RESTAPI_CA_FILE'], overwrite)
         else:

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -127,6 +127,30 @@ def write_certificates(environment, overwrite):
     adjust_owner(environment['SSL_PRIVATE_KEY_FILE'], gid=-1)
 
 
+def write_restapi_certificates(environment, overwrite):
+    """Write REST Api SSL certificate to files
+
+    If certificates are specified, they are written, otherwise
+    dummy certificates are generated and written"""
+
+    ssl_keys = ['SSL_RESTAPI_CERTIFICATE', 'SSL_RESTAPI_PRIVATE_KEY']
+    if set(ssl_keys) <= set(environment):
+        logging.info('Writing REST Api custom ssl certificate')
+        for k in ssl_keys:
+            write_file(environment[k], environment[k + '_FILE'], overwrite)
+        if 'SSL_RESTAPI_CA' in environment:
+            if environment['SSL_RESTAPI_CA_FILE'] == '':
+                environment['SSL_RESTAPI_CA_FILE'] = os.path.join(environment['RW_DIR'], 'certs',
+                                                                  'rest-api-server-ca.crt')
+            logging.info('Writing REST Api ssl ca certificate')
+            write_file(environment['SSL_RESTAPI_CA'], environment['SSL_RESTAPI_CA_FILE'], overwrite)
+        else:
+            logging.info('No REST Api ca certificate to write')
+
+        os.chmod(environment['SSL_RESTAPI_PRIVATE_KEY_FILE'], 0o600)
+        adjust_owner(environment['SSL_RESTAPI_PRIVATE_KEY_FILE'], gid=-1)
+
+
 def deep_update(a, b):
     """Updates data structures
 
@@ -244,6 +268,15 @@ scope: &scope '{{SCOPE}}'
 restapi:
   listen: ':{{APIPORT}}'
   connect_address: {{instance_data.ip}}:{{APIPORT}}
+  {{#SSL_RESTAPI_CA_FILE}}
+  cafile: {{SSL_RESTAPI_CA_FILE}}
+  {{/SSL_RESTAPI_CA_FILE}}
+  {{#SSL_RESTAPI_CERTIFICATE_FILE}}
+  certfile: {{SSL_RESTAPI_CERTIFICATE_FILE}}
+  {{/SSL_RESTAPI_CERTIFICATE_FILE}}
+  {{#SSL_RESTAPI_PRIVATE_KEY_FILE}}
+  keyfile: {{SSL_RESTAPI_PRIVATE_KEY_FILE}}
+  {{/SSL_RESTAPI_PRIVATE_KEY_FILE}}
 postgresql:
   pgpass: /run/postgresql/pgpass
   use_unix_socket: true
@@ -504,6 +537,11 @@ def get_placeholders(provider):
     placeholders.setdefault('SSL_CRL_FILE', '')
     placeholders.setdefault('SSL_CERTIFICATE_FILE', os.path.join(placeholders['RW_DIR'], 'certs', 'server.crt'))
     placeholders.setdefault('SSL_PRIVATE_KEY_FILE', os.path.join(placeholders['RW_DIR'], 'certs', 'server.key'))
+    placeholders.setdefault('SSL_RESTAPI_CA_FILE', '')
+    placeholders.setdefault('SSL_RESTAPI_CERTIFICATE_FILE', os.path.join(placeholders['RW_DIR'], 'certs',
+                            'rest-api-server.crt'))
+    placeholders.setdefault('SSL_RESTAPI_PRIVATE_KEY_FILE', os.path.join(placeholders['RW_DIR'], 'certs',
+                            'restapi-api-server.key'))
     placeholders.setdefault('WALE_BACKUP_THRESHOLD_MEGABYTES', 102400)
     placeholders.setdefault('WALE_BACKUP_THRESHOLD_PERCENTAGE', 30)
     placeholders.setdefault('INITDB_LOCALE', 'en_US')
@@ -627,6 +665,15 @@ def get_placeholders(provider):
         placeholders['SSL_CA_FILE'] = os.path.join(placeholders['RW_DIR'], 'certs', 'ca.crt')
     if 'SSL_CRL' in placeholders and placeholders['SSL_CRL_FILE'] == '':
         placeholders['SSL_CRL_FILE'] = os.path.join(placeholders['RW_DIR'], 'certs', 'server.crl')
+
+    ssl_keys = ['SSL_RESTAPI_CERTIFICATE', 'SSL_RESTAPI_PRIVATE_KEY']
+    if not set(ssl_keys) <= set(placeholders):
+        placeholders['SSL_RESTAPI_CERTIFICATE_FILE'] = ''
+        placeholders['SSL_RESTAPI_PRIVATE_KEY_FILE'] = ''
+        placeholders['SSL_RESTAPI_CA_FILE'] = ''
+        placeholders['SSL_RESTAPI_CA'] = ''
+    elif 'SSL_RESTAPI_CA' in placeholders and placeholders['SSL_RESTAPI_CA_FILE'] == '':
+        placeholders['SSL_RESTAPI_CA_FILE'] = os.path.join(placeholders['RW_DIR'], 'certs', 'rest-api-ca.crt')
 
     return placeholders
 
@@ -1031,6 +1078,7 @@ def main():
                 write_wale_environment(placeholders, '', args['force'])
         elif section == 'certificate':
             write_certificates(placeholders, args['force'])
+            write_restapi_certificates(placeholders, args['force'])
         elif section == 'crontab':
             write_crontab(placeholders, args['force'])
         elif section == 'pam-oauth2':

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -538,10 +538,8 @@ def get_placeholders(provider):
     placeholders.setdefault('SSL_CERTIFICATE_FILE', os.path.join(placeholders['RW_DIR'], 'certs', 'server.crt'))
     placeholders.setdefault('SSL_PRIVATE_KEY_FILE', os.path.join(placeholders['RW_DIR'], 'certs', 'server.key'))
     placeholders.setdefault('SSL_RESTAPI_CA_FILE', '')
-    placeholders.setdefault('SSL_RESTAPI_CERTIFICATE_FILE', os.path.join(placeholders['RW_DIR'], 'certs',
-                            'rest-api-server.crt'))
-    placeholders.setdefault('SSL_RESTAPI_PRIVATE_KEY_FILE', os.path.join(placeholders['RW_DIR'], 'certs',
-                            'restapi-api-server.key'))
+    placeholders.setdefault('SSL_RESTAPI_CERTIFICATE_FILE', '')
+    placeholders.setdefault('SSL_RESTAPI_PRIVATE_KEY_FILE', '')
     placeholders.setdefault('WALE_BACKUP_THRESHOLD_MEGABYTES', 102400)
     placeholders.setdefault('WALE_BACKUP_THRESHOLD_PERCENTAGE', 30)
     placeholders.setdefault('INITDB_LOCALE', 'en_US')

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -666,13 +666,14 @@ def get_placeholders(provider):
     if 'SSL_CRL' in placeholders and placeholders['SSL_CRL_FILE'] == '':
         placeholders['SSL_CRL_FILE'] = os.path.join(placeholders['RW_DIR'], 'certs', 'server.crl')
 
-    ssl_keys = ['SSL_RESTAPI_CERTIFICATE', 'SSL_RESTAPI_PRIVATE_KEY']
-    if not set(ssl_keys) <= set(placeholders):
-        placeholders['SSL_RESTAPI_CERTIFICATE_FILE'] = ''
-        placeholders['SSL_RESTAPI_PRIVATE_KEY_FILE'] = ''
-        placeholders['SSL_RESTAPI_CA_FILE'] = ''
-        placeholders['SSL_RESTAPI_CA'] = ''
-    elif 'SSL_RESTAPI_CA' in placeholders and placeholders['SSL_RESTAPI_CA_FILE'] == '':
+    if {'SSL_RESTAPI_CERTIFICATE', 'SSL_RESTAPI_PRIVATE_KEY'} <= set(placeholders):
+        if not placeholders['SSL_RESTAPI_CERTIFICATE_FILE']:
+            placeholders['SSL_RESTAPI_CERTIFICATE_FILE'] = os.path.join(placeholders['RW_DIR'], 'certs',
+                                                                        'rest-api-server.crt')
+        if not placeholders['SSL_RESTAPI_PRIVATE_KEY_FILE']:
+            placeholders['SSL_RESTAPI_PRIVATE_KEY_FILE'] = os.path.join(placeholders['RW_DIR'], 'certs',
+                                                                        'restapi-api-server.key')
+    if placeholders.get('SSL_RESTAPI_CA') and not placeholders['SSL_RESTAPI_CA_FILE']:
         placeholders['SSL_RESTAPI_CA_FILE'] = os.path.join(placeholders['RW_DIR'], 'certs', 'rest-api-ca.crt')
 
     return placeholders


### PR DESCRIPTION
Spilo does not have environment variables to set up Patroni REST API SSL certificates like for PostgreSQL. This PR introduces the following variables:

* **SSL_RESTAPI_CA_FILE**
* **SSL_RESTAPI_CERTIFICATE_FILE**
* **SSL_RESTAPI_PRIVATE_KEY_FILE**
* **SSL_RESTAPI_CA**
* **SSL_RESTAPI_CERTIFICATE**
* **SSL_RESTAPI_PRIVATE_KEY**

read the changes in ENVIRONMENT.rst for the meaning of each variable.