### PR TITLE
Fixed postgres_backup.sh script for wal-g 1.1

### DIFF
--- a/postgres-appliance/scripts/postgres_backup.sh
+++ b/postgres-appliance/scripts/postgres_backup.sh
@@ -53,7 +53,7 @@ while read -r name last_modified rest; do
         # count how many backups will remain after we remove everything up to certain date
         ((LEFT=LEFT+1))
     fi
-done < <($WAL_E backup-list 2> /dev/null | sed '0,/^name\s*last_modified\s*/d')
+done < <($WAL_E backup-list 2> /dev/null | sed '0,/^name\s*\(last_\)\?modified\s*/d')
 
 # we want keep at least N backups even if the number of days exceeded
 if [ ! -z "$BEFORE" ] && [ $LEFT -ge $DAYS_TO_RETAIN ]; then


### PR DESCRIPTION
Fixed the `sed` command in the `postgres_backup.sh` script to handle wal-g 1.1 headers