### PR TITLE
Add PGroonga extension

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -53,6 +53,17 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     done \
     && curl -s -o - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
 \
+    # Add pgroonga repositories
+    # Libs + for version 9.6
+    && for t in deb deb-src; do \
+        echo "$t http://ppa.launchpad.net/groonga/ppa/ubuntu ${DISTRIB_CODENAME} main" >> /etc/apt/sources.list.d/pgroonga.list; \
+    done \
+    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8678AF29D1B5ABA1A5A651063359E7CECB64A157 \
+    # For versions 10-13
+    && curl "https://packages.groonga.org/ubuntu/groonga-apt-source-latest-${DISTRIB_CODENAME}.deb" -o groonga-apt-source-latest.deb  \
+    && apt-get install -y ./groonga-apt-source-latest.deb \
+    && rm ./groonga-apt-source-latest.deb \
+\
     # Clean up
     && apt-get purge -y libcap2-bin \
     && apt-get autoremove -y \
@@ -168,6 +179,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
                 fi \
                 && if [ ${version%.*} -lt 11 ]; then \
                     EXTRAS="$EXTRAS postgresql-${version}-amcheck"; \
+                fi \
+                && if [ ${version%.*} -ge 10 ]; then \
+                    EXTRAS="$EXTRAS postgresql-${version}-pgdg-pgroonga"; \
                 fi; \
             fi \
 \


### PR DESCRIPTION
PGroonga is quite popular extension for full text search in Japanese, Chinese and other asian languages. This PR adds it to spilo image.

From [official website](https://pgroonga.github.io/):
> PostgreSQL supports full text search against languages that use only alphabet and digit. It means that PostgreSQL doesn't support full text search against Japanese, Chinese and so on. You can use super fast full text search feature against all languages by installing PGroonga into your PostgreSQL!

[PGroonga's GitHub](https://github.com/pgroonga/pgroonga)