### PR TITLE
Define RESTAPI_CONNECT_ADDRESS environment variable

### DIFF
--- a/ENVIRONMENT.rst
+++ b/ENVIRONMENT.rst
@@ -41,7 +41,8 @@ Environment Configuration Settings
 - **SSL_RESTAPI_CA**: content of the Patroni REST Api SSL CA certificate in the SSL_RESTAPI_CA_FILE file (by default: '')
 - **SSL_RESTAPI_CERTIFICATE**: content of the REST Api SSL certificate in the SSL_CERTIFICATE_FILE file (by default /run/certs/server.crt).
 - **SSL_RESTAPI_PRIVATE_KEY**: content of the REST Api SSL private key in the SSL_PRIVATE_KEY_FILE file (by default /run/certs/server.key).
-- **SSL_TEST_RELOAD**: whenever to test for certificate rotation and reloading (by default True if SSL_PRIVATE_KEY_FILE has been set)
+- **SSL_TEST_RELOAD**: whenever to test for certificate rotation and reloading (by default True if SSL_PRIVATE_KEY_FILE has been set).
+- **RESTAPI_CONNECT_ADDRESS**: when you configure Patroni RESTAPI in SSL mode some safe API (i.e. switchover) perform hostname validation. In this case could be convenient configure ````restapi.connect_address````as a hostname instead of IP. For example, you can configure it as "$(POD_NAME).<service name>".
 - **WALE_BACKUP_THRESHOLD_MEGABYTES**: maximum size of the WAL segments accumulated after the base backup to consider WAL-E restore instead of pg_basebackup.
 - **WALE_BACKUP_THRESHOLD_PERCENTAGE**: maximum ratio (in percents) of the accumulated WAL files to the base backup to consider WAL-E restore instead of pg_basebackup.
 - **WALE_ENV_DIR**: directory where to store WAL-E environment variables

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -264,7 +264,7 @@ bootstrap:
 scope: &scope '{{SCOPE}}'
 restapi:
   listen: ':{{APIPORT}}'
-  connect_address: {{REST_API_CONNECT_ADDRESS}}:{{APIPORT}}
+  connect_address: {{RESTAPI_CONNECT_ADDRESS}}:{{APIPORT}}
   {{#SSL_RESTAPI_CA_FILE}}
   cafile: {{SSL_RESTAPI_CA_FILE}}
   {{/SSL_RESTAPI_CA_FILE}}
@@ -653,7 +653,7 @@ def get_placeholders(provider):
     placeholders['postgresql']['parameters']['max_connections'] = min(max(100, int(os_memory_mb/30)), 1000)
 
     placeholders['instance_data'] = get_instance_metadata(provider)
-    placeholders.setdefault('REST_API_CONNECT_ADDRESS', placeholders['instance_data']['ip'])
+    placeholders.setdefault('RESTAPI_CONNECT_ADDRESS', placeholders['instance_data']['ip'])
 
     placeholders['BGMON_LISTEN_IP'] = get_listen_ip()
 

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -264,7 +264,7 @@ bootstrap:
 scope: &scope '{{SCOPE}}'
 restapi:
   listen: ':{{APIPORT}}'
-  connect_address: {{instance_data.ip}}:{{APIPORT}}
+  connect_address: {{REST_API_CONNECT_ADDRESS}}:{{APIPORT}}
   {{#SSL_RESTAPI_CA_FILE}}
   cafile: {{SSL_RESTAPI_CA_FILE}}
   {{/SSL_RESTAPI_CA_FILE}}
@@ -653,6 +653,7 @@ def get_placeholders(provider):
     placeholders['postgresql']['parameters']['max_connections'] = min(max(100, int(os_memory_mb/30)), 1000)
 
     placeholders['instance_data'] = get_instance_metadata(provider)
+    placeholders.setdefault('REST_API_CONNECT_ADDRESS', placeholders['instance_data']['ip'])
 
     placeholders['BGMON_LISTEN_IP'] = get_listen_ip()
 


### PR DESCRIPTION
Spilo by default uses IP for the property ```restapi.connect_address```. This is a problem when Patroni REST API is configured in SSL with client authentication because hostname validation is performed. Due to the dynamic nature of Pod, it's impossible to create SSL certificates with the right IP into SAN.
This PR solves the problem with the introduction of the property: REST_API_CONNECT_ADDRESS.
You can configure it, for example, like this:
```
        - name: RESTAPI_CONNECT_ADDRESS
          value: "$(POD_NAME).<service name>"
``` 

so that it uses the <pod name>.<service name> stored in CoreDNS.