### PR TITLE
docs: WAL_S3_BUCKET is not s3:// path

### DIFF
--- a/ENVIRONMENT.rst
+++ b/ENVIRONMENT.rst
@@ -46,7 +46,7 @@ Environment Configuration Settings
 - **WALE_BACKUP_THRESHOLD_MEGABYTES**: maximum size of the WAL segments accumulated after the base backup to consider WAL-E restore instead of pg_basebackup.
 - **WALE_BACKUP_THRESHOLD_PERCENTAGE**: maximum ratio (in percents) of the accumulated WAL files to the base backup to consider WAL-E restore instead of pg_basebackup.
 - **WALE_ENV_DIR**: directory where to store WAL-E environment variables
-- **WAL_S3_BUCKET**: (optional) path to the S3 bucket used for WAL-E base backups (i.e. s3://foobar). Spilo will add /spilo/scope/wal to that path.
+- **WAL_S3_BUCKET**: (optional) name of the S3 bucket used for WAL-E base backups.
 - **AWS_ACCESS_KEY_ID**: (optional) aws access key
 - **AWS_SECRET_ACCESS_KEY**: (optional) aws secret key
 - **AWS_REGION**: (optional) region of S3 bucket


### PR DESCRIPTION
We will add "s3://" to the *_PREFIX \[1], so it should not appear in WAL_S3_BUCKET.

Besides, "Spilo will add /spilo/scope/wal to that path" is not true now (we added PGVERSION). So just remove it.

\[1]: https://github.com/zalando/spilo/blob/9f37ab473caea1e4420d8f4da8773a4938d9310b/postgres-appliance/scripts/configure_spilo.py#L830