### PR TITLE
Various fixes

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -11,6 +11,7 @@ pipeline:
   commands:
   - desc: Build spilo docker image
     cmd: |
+      chmod -R o-w postgres-appliance
       cd postgres-appliance
       docker build --build-arg PGVERSION=$PGVERSION --build-arg BASE_IMAGE=$BASE_IMAGE -t spilo .
       docker images
@@ -72,6 +73,7 @@ pipeline:
       docker run --privileged --rm tonistiigi/binfmt --install "$ARCH"
   - desc: Build spilo-cdp-arm64 docker image
     cmd: |
+      chmod -R o-w postgres-appliance
       cd postgres-appliance
       docker buildx build --platform "linux/$ARCH" --build-arg PGVERSION=$PGVERSION -t spilo .
       docker images

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -67,6 +67,8 @@ pipeline:
   timeout: 10h
   vm_config:
     type: linux
+    size: large
+    priority: 3
   commands:
   - desc: Setup environment
     cmd: |

--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -538,6 +538,7 @@ RUN sed -i "s|/var/lib/postgresql.*|$PGHOME:/bin/bash|" /etc/passwd \
         # Allow users in the root group to access the following files and dirs
         && if [ "$COMPRESS" != "true" ]; then \
            chmod 664 /etc/passwd \
+           && chmod o+r /etc/shadow \
            && chgrp -R 0 $PGHOME $RW_DIR \
            && chmod -R g=u $PGHOME $RW_DIR \
            && usermod -a -G root postgres; \

--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -512,6 +512,10 @@ RUN sed -i "s|/var/lib/postgresql.*|$PGHOME:/bin/bash|" /etc/passwd \
         && mkdir -p /var/spool \
         && ln -s $RW_DIR/cron /var/spool/cron \
         && ln -s $RW_DIR/tmp /var/tmp \
+        && for d in /etc/service/*; do \
+            chmod 750 $d/* \
+            && ln -s /run/supervise/$(basename $d) $d/supervise; \
+        done \
         && ln -snf $RW_DIR/service /etc/service \
         && ln -s $RW_DIR/pam.d-postgresql /etc/pam.d/postgresql \
         && ln -s $RW_DIR/postgres.yml $PGHOME/postgres.yml \

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -70,14 +70,13 @@ def adjust_owner(resource, uid=None, gid=None):
 
 
 def link_runit_service(placeholders, name):
-    service_dir = os.path.join(placeholders['RW_DIR'], 'service', name)
+    rw_service = os.path.join(placeholders['RW_DIR'], 'service')
+    service_dir = os.path.join(rw_service, name)
     if not os.path.exists(service_dir):
-        os.makedirs(service_dir)
-        for f in ('run', 'finish'):
-            src_file = os.path.join('/etc/runit/runsvdir/default', name, f)
-            dst_file = os.path.join(service_dir, f)
-            if os.path.exists(src_file) and not os.path.exists(dst_file):
-                os.symlink(src_file, dst_file)
+        if not os.path.exists(rw_service):
+            os.makedirs(rw_service)
+        os.symlink(os.path.join('/etc/runit/runsvdir/default', name), service_dir)
+        os.makedirs(os.path.join(placeholders['RW_DIR'], 'supervise', name))
 
 
 def write_certificates(environment, overwrite):


### PR DESCRIPTION
1. Ensure files copied from git repo are not world-writable. The problem seems to be very specific to Zalando CPD, that possibly does git clone with umask=0000
2. Read-only rootfs: create symlinks only to corresponding runit directories instead of individual `run` and `finish` files.
3. Fix bug with the cron daemon running from the postgres user. While the daemon was running since https://github.com/zalando/spilo/commit/c91248e26e2ea910304d04a3acbeda1e965e2e42#diff-dd039299d1b892e68ab0ea5e22d533814e1c349a290b5cc46b9d823578f6b741, individual jobs were failing to start because
PAM was failing to read /etc/shadow.
4.  Run "arm64" build on the "large" instance. Having more CPU cores available significantly speeds up the build.