### PR TITLE
Try get ip from OpenStack EC2-compatible API

### DIFF
--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -443,9 +443,12 @@ def get_instance_metadata(provider):
         openstack_metadata = requests.get(url, timeout=5).json()
         metadata['zone'] = openstack_metadata['availability_zone']
         if not USE_KUBERNETES:
-            # OpenStack does not support providing an IP through metadata so keep
-            # auto-discovered one.
+            # Try get IP via OpenStack EC2-compatible API, if can't then fail back to auto-discovered one.
             metadata['id'] = openstack_metadata.uuid
+            url = 'http://169.254.169.254/2009-04-04/meta-data'
+            r = requests.get(url)
+            if r.ok:
+                mapping.update({'ip': 'local-ipv4', 'id': 'instance-id'}) 
     else:
         logging.info("No meta-data available for this provider")
         return metadata


### PR DESCRIPTION
OpenStack metadata service supports two sets of APIs: an OpenStack metadata API and an EC2-compatible API, The metadata service has an API that is compatible with version 2009-04-04 of the Amazon EC2 metadata service. We should try get instance ip from it first.