### PR TITLE
Implement non-exclusive backups with wal-e

### DIFF
--- a/ENVIRONMENT.rst
+++ b/ENVIRONMENT.rst
@@ -92,6 +92,7 @@ Environment Configuration Settings
 - **KUBERNETES_LABELS**: a JSON describing names and values of other labels used by Patroni on Kubernetes to locate its metadata. Default is '{"application": "spilo"}'.
 - **INITDB_LOCALE**: database cluster's default UTF-8 locale (en_US by default)
 - **ENABLE_WAL_PATH_COMPAT**: old Spilo images were generating wal path in the backup store using the following template ``/spilo/{WAL_BUCKET_SCOPE_PREFIX}{SCOPE}{WAL_BUCKET_SCOPE_SUFFIX}/wal/``, while new images adding one additional directory (``{PGVERSION}``) to the end. In order to avoid (unlikely) issues with restoring WALs (from S3/GC/and so on) when switching to ``spilo-13`` please set the ``ENABLE_WAL_PATH_COMPAT=true`` when deploying old cluster with ``spilo-13`` for the first time. After that the environment variable could be removed. Change of the WAL path also mean that backups stored in the old location will not be cleaned up automatically.
+- **WALE_DISABLE_S3_SSE**, **WALG_DISABLE_S3_SSE**: by default wal-e/wal-g are configured to encrypt files uploaded to S3. In order to disable it you can set this environment variable to ``true``.
 
 wal-g
 -----

--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -420,6 +420,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         && pip3 install filechunkio wal-e[aws,google,swift]==$WALE_VERSION google-crc32c==1.1.2 \
                 'git+https://github.com/zalando/pg_view.git@master#egg=pg-view' \
 \
+        # Non-exclusive backups
+        && curl -sL https://github.com/CyberDem0n/wal-e/commit/db831a1cbe2f96703e8860e8e07b7e93fbaf095d.diff \
+                | patch -d /usr/local/lib/python3.6/dist-packages/wal_e -p2 \
         # Revert https://github.com/wal-e/wal-e/commit/485d834a18c9b0d97115d95f89e16bdc564e9a18, it affects S3 performance
         && curl -sL https://github.com/wal-e/wal-e/commit/485d834a18c9b0d97115d95f89e16bdc564e9a18.diff \
                 | patch -d /usr/local/lib/python3.6/dist-packages/wal_e -Rp2 \

--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -421,7 +421,10 @@ RUN export DEBIAN_FRONTEND=noninteractive \
                 'git+https://github.com/zalando/pg_view.git@master#egg=pg-view' \
 \
         # Non-exclusive backups
-        && curl -sL https://github.com/CyberDem0n/wal-e/commit/db831a1cbe2f96703e8860e8e07b7e93fbaf095d.diff \
+        && curl -sL https://github.com/CyberDem0n/wal-e/commit/dad4d53969b93c56f1eaa5243ffa8e9051fd7eb7.diff \
+                | patch -d /usr/local/lib/python3.6/dist-packages/wal_e -p2 \
+        # WALE_DISABLE_S3_SSE support
+        && curl -sL https://github.com/CyberDem0n/wal-e/commit/0309317d33d252fcd968b3eb97313a9fdf022c65.diff \
                 | patch -d /usr/local/lib/python3.6/dist-packages/wal_e -p2 \
         # Revert https://github.com/wal-e/wal-e/commit/485d834a18c9b0d97115d95f89e16bdc564e9a18, it affects S3 performance
         && curl -sL https://github.com/wal-e/wal-e/commit/485d834a18c9b0d97115d95f89e16bdc564e9a18.diff \

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -1055,27 +1055,6 @@ def main():
                 os.makedirs(pg_socket_dir)
                 os.chmod(pg_socket_dir, 0o2775)
                 adjust_owner(pg_socket_dir)
-
-            # It is a recurring and very annoying problem with crashes (host/pod/container)
-            # while the backup is taken in the exclusive mode which leaves the backup_label
-            # in the PGDATA. Having the backup_label file in the PGDATA makes postgres think
-            # that we are restoring from the backup and it puts this information into the
-            # pg_control. Effectively it makes it impossible to start postgres in recovery
-            # with such PGDATA because the recovery never-ever-ever-ever finishes.
-            #
-            # As a workaround we will remove the backup_label file from PGDATA if we know
-            # for sure that the Postgres was already running with exactly this PGDATA.
-            # As proof that the postgres was running we will use the presence of postmaster.pid
-            # in the PGDATA, because it is 100% known that neither pg_basebackup nor
-            # wal-e/wal-g are backing up/restoring this file.
-            #
-            # We are not doing such trick in the Patroni (removing backup_label) because
-            # we have absolutely no idea what software people use for backup/recovery.
-            # In case of some home-grown solution they might end up in copying postmaster.pid...
-            postmaster_pid = os.path.join(pgdata, 'postmaster.pid')
-            backup_label = os.path.join(pgdata, 'backup_label')
-            if os.path.isfile(postmaster_pid) and os.path.isfile(backup_label):
-                os.unlink(backup_label)
         elif section == 'pgqd':
             link_runit_service(placeholders, 'pgqd')
         elif section == 'log':

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -751,7 +751,7 @@ def write_log_environment(placeholders):
 
 def write_wale_environment(placeholders, prefix, overwrite):
     s3_names = ['WALE_S3_PREFIX', 'WALG_S3_PREFIX', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY',
-                'WALE_S3_ENDPOINT', 'AWS_ENDPOINT', 'AWS_REGION', 'AWS_INSTANCE_PROFILE',
+                'WALE_S3_ENDPOINT', 'AWS_ENDPOINT', 'AWS_REGION', 'AWS_INSTANCE_PROFILE', 'WALE_DISABLE_S3_SSE',
                 'WALG_S3_SSE_KMS_ID', 'WALG_S3_SSE', 'WALG_DISABLE_S3_SSE', 'AWS_S3_FORCE_PATH_STYLE']
     azure_names = ['WALG_AZ_PREFIX', 'AZURE_STORAGE_ACCOUNT', 'AZURE_STORAGE_ACCESS_KEY',
                    'AZURE_STORAGE_SAS_TOKEN', 'WALG_AZURE_BUFFER_SIZE', 'WALG_AZURE_MAX_BUFFERS']
@@ -794,7 +794,8 @@ def write_wale_environment(placeholders, prefix, overwrite):
                                     'but got %s', wale_endpoint)
                 if not aws_endpoint:
                     aws_endpoint = match.expand(r'\1\3') if match else wale_endpoint
-            wale.update(WALE_S3_ENDPOINT=wale_endpoint, AWS_ENDPOINT=aws_endpoint, WALG_DISABLE_S3_SSE='true')
+            wale.update(WALE_S3_ENDPOINT=wale_endpoint, AWS_ENDPOINT=aws_endpoint,
+                        WALG_DISABLE_S3_SSE='true', WALE_DISABLE_S3_SSE='true')
             wale['AWS_S3_FORCE_PATH_STYLE'] = 'true' if convention == 'path' else 'false'
             if aws_region and wale.get('USE_WALG_BACKUP') == 'true':
                 wale['AWS_REGION'] = aws_region
@@ -812,6 +813,10 @@ def write_wale_environment(placeholders, prefix, overwrite):
 
         if not (wale.get('AWS_SECRET_ACCESS_KEY') and wale.get('AWS_ACCESS_KEY_ID')):
             wale['AWS_INSTANCE_PROFILE'] = 'true'
+
+        if wale.get('WALE_DISABLE_S3_SSE') and not wale.get('WALG_DISABLE_S3_SSE'):
+            wale['WALG_DISABLE_S3_SSE'] = wale['WALE_DISABLE_S3_SSE']
+
         if wale.get('USE_WALG_BACKUP') and wale.get('WALG_DISABLE_S3_SSE') != 'true' and not wale.get('WALG_S3_SSE'):
             wale['WALG_S3_SSE'] = 'AES256'
         write_envdir_names = s3_names + walg_names

--- a/postgres-appliance/tests/docker-compose.yml
+++ b/postgres-appliance/tests/docker-compose.yml
@@ -33,8 +33,8 @@ services:
             AWS_ENDPOINT: &aws_endpoint 'http://minio:9000'
             AWS_S3_FORCE_PATH_STYLE: &aws_s3_force_path_style 'true'
             WAL_S3_BUCKET: &bucket testbucket
-            USE_WALG: 'true'
-            WALG_DISABLE_S3_SSE: &walg_disable_s3_sse 'true'
+#            USE_WALG: 'true'  # wal-e is used and tested by default, wal-g is used automatically for restore in case of S3
+            WALE_DISABLE_S3_SSE: &wale_disable_s3_sse 'true'
             ETCDCTL_ENDPOINTS: http://etcd:2379
             ETCD_HOST: "etcd:2379"
             SCOPE: demo
@@ -56,7 +56,7 @@ services:
             CLONE_AWS_SECRET_ACCESS_KEY: *secret_key
             CLONE_AWS_ENDPOINT: *aws_endpoint
             CLONE_AWS_S3_FORCE_PATH_STYLE: *aws_s3_force_path_style
-            CLONE_WALG_DISABLE_S3_SSE: *walg_disable_s3_sse
+            CLONE_WALE_DISABLE_S3_SSE: *wale_disable_s3_sse
         hostname: spilo1
         container_name: demo-spilo1
 


### PR DESCRIPTION
It makes it redundant to remove the backup_label file from the configure_spilo.py