### PR TITLE
Add retry to launch.sh for configure_spilo.py

### DIFF
--- a/postgres-appliance/launch.sh
+++ b/postgres-appliance/launch.sh
@@ -46,6 +46,14 @@ elif python3 /scripts/configure_spilo.py all; then
     else
         $CMD &
     fi
+else ## /scripts/configure_spilo failed.  Try one more time after a brief pause.
+    sleep 2
+    CMD="/scripts/patroni_wait.sh -t 3600 -- envdir $WALE_ENV_DIR /scripts/postgres_backup.sh $PGDATA"
+    if [ "$(id -u)" = "0" ]; then
+        su postgres -c "PATH=$PATH $CMD" &
+    else
+        $CMD &
+    fi
 fi
 
 sv_stop() {

--- a/postgres-appliance/launch.sh
+++ b/postgres-appliance/launch.sh
@@ -47,6 +47,7 @@ elif python3 /scripts/configure_spilo.py all; then
         $CMD &
     fi
 else ## /scripts/configure_spilo failed.  Try one more time after a brief pause.
+    echo "/launch.sh: /scripts/configure_spilo.py failed.  Retrying after a brief delay..."
     sleep 2
     CMD="/scripts/patroni_wait.sh -t 3600 -- envdir $WALE_ENV_DIR /scripts/postgres_backup.sh $PGDATA"
     if [ "$(id -u)" = "0" ]; then


### PR DESCRIPTION
Add a small delay and single retry for /scripts/configure_spilo.py from /launch.sh.

It is possible that a large cluster with iptables-enforced network policies could have an ever so brief delay in enforcing network policies.  In my testing it was possible to trigger in a ~150 node cluster with sufficient regularity to cause additional admin work.  Having a single retry after a few seconds alleviates the issue so we don't have to destroy/recreate the pod (and if it still fails after the retry, we'll destroy/recreate the pod anyways, so the only cost is a brief delay upon initial failure).

This could potentially be improved with exponential backoff retries, but I've opted for the simplest approach at this point in time.  I am, however, open to any and all feedback on the PR.

Related to: https://github.com/zalando/spilo/issues/511