### PR TITLE
etcd, tar xz: --no-same-owner, for "rootless Jenkins job"

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -74,8 +74,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         # install etcdctl
         && ETCDVERSION=3.3.27 \
         && curl -L https://github.com/coreos/etcd/releases/download/v${ETCDVERSION}/etcd-v${ETCDVERSION}-linux-$(dpkg --print-architecture).tar.gz \
-                | tar xz -C /bin --strip=1 --wildcards --no-anchored etcdctl etcd \
-        && chown root:root /bin/etcd*; \
+                | tar xz -C /bin --strip=1 --wildcards --no-anchored --no-same-owner etcdctl etcd; \
     fi \
 \
     # Cleanup all locales but en_US.UTF-8 and optionally specified in ADDITIONAL_LOCALES arg


### PR DESCRIPTION
https://github.com/zalando/spilo/issues/708
We would need to make "docker build" work in a job in e.g. Jenkins, with "rootless" linux user job.
"rootless": Executor/job of Jenkins uses a container/image where root linux user is not used / does not exist. --> In a "rootless" docker building job.