### PR TITLE
Allow passing `PATRONI_LOG_*` environment variables to patroni process.

### DIFF
--- a/postgres-appliance/runit/patroni/run
+++ b/postgres-appliance/runit/patroni/run
@@ -21,7 +21,7 @@ fi
 ulimit -c unlimited
 
 # Only small subset of environment variables is allowed. We don't want accidentally disclose sensitive information
-for E in $(printenv -0 | tr '\n' ' ' | sed 's/\x00/\n/g' | grep -vE '^(KUBERNETES_(SERVICE|PORT|ROLE)[_=]|((POD_(IP|NAMESPACE))|HOSTNAME|PATH|PGHOME|LC_ALL|ENABLE_PG_MON)=)' | sed 's/=.*//g'); do
+for E in $(printenv -0 | tr '\n' ' ' | sed 's/\x00/\n/g' | grep -vE '^(KUBERNETES_(SERVICE|PORT|ROLE)[_=]|((POD_(IP|NAMESPACE))|HOSTNAME|PATH|PGHOME|LC_ALL|ENABLE_PG_MON)=)|(PATRONI_LOG_.*=)' | sed 's/=.*//g'); do
     unset $E
 done
 


### PR DESCRIPTION
Quick change to the patroni run script to allow passing just patroni log config to  the patroni process. This configuration should not have any sensitive information, so should be fine to pass along.

fixes https://github.com/zalando/spilo/issues/718.