### PR TITLE
Fall back in case wal-g restore_command hangs

### DIFF
--- a/ENVIRONMENT.rst
+++ b/ENVIRONMENT.rst
@@ -46,6 +46,7 @@ Environment Configuration Settings
 - **WALE_BACKUP_THRESHOLD_MEGABYTES**: maximum size of the WAL segments accumulated after the base backup to consider WAL-E restore instead of pg_basebackup.
 - **WALE_BACKUP_THRESHOLD_PERCENTAGE**: maximum ratio (in percents) of the accumulated WAL files to the base backup to consider WAL-E restore instead of pg_basebackup.
 - **WALE_ENV_DIR**: directory where to store WAL-E environment variables
+- **WAL_RESTORE_TIMEOUT**: timeout (in seconds) for restoring a single WAL file (at most 16 MB) from the backup location, 0 by default. A duration of 0 disables the timeout.
 - **WAL_S3_BUCKET**: (optional) name of the S3 bucket used for WAL-E base backups.
 - **AWS_ACCESS_KEY_ID**: (optional) aws access key
 - **AWS_SECRET_ACCESS_KEY**: (optional) aws secret key

--- a/postgres-appliance/major_upgrade/inplace_upgrade.py
+++ b/postgres-appliance/major_upgrade/inplace_upgrade.py
@@ -52,7 +52,7 @@ def update_configs(new_version):
 
     # update wal-e/wal-g envdir files
     restore_command = shlex.split(config['postgresql'].get('recovery_conf', {}).get('restore_command', ''))
-    if len(restore_command) > 4 and restore_command[0] == 'envdir':
+    if len(restore_command) > 6 and restore_command[0] == 'envdir':
         envdir = restore_command[1]
 
         try:

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -180,7 +180,8 @@ bootstrap:
       {{/STANDBY_WITH_WALE}}
       - basebackup_fast_xlog
       {{#STANDBY_WITH_WALE}}
-      restore_command: envdir "{{STANDBY_WALE_ENV_DIR}}" /scripts/restore_command.sh "%f" "%p"
+      restore_command: envdir "{{STANDBY_WALE_ENV_DIR}}" timeout "{{WAL_RESTORE_TIMEOUT}}"
+        /scripts/restore_command.sh "%f" "%p"
       {{/STANDBY_WITH_WALE}}
       {{#STANDBY_HOST}}
       host: {{STANDBY_HOST}}
@@ -228,7 +229,8 @@ bootstrap:
     command: envdir "{{CLONE_WALE_ENV_DIR}}" python3 /scripts/clone_with_wale.py
       --recovery-target-time="{{CLONE_TARGET_TIME}}"
     recovery_conf:
-        restore_command: envdir "{{CLONE_WALE_ENV_DIR}}" /scripts/restore_command.sh "%f" "%p"
+        restore_command: envdir "{{CLONE_WALE_ENV_DIR}}" timeout "{{WAL_RESTORE_TIMEOUT}}"
+          /scripts/restore_command.sh "%f" "%p"
         recovery_target_timeline: latest
         {{#USE_PAUSE_AT_RECOVERY_TARGET}}
         recovery_target_action: pause
@@ -335,7 +337,8 @@ ltree,pgcrypto,pgq,pg_trgm,postgres_fdw,tablefunc,uuid-ossp,hypopg'
 
   {{#USE_WALE}}
   recovery_conf:
-    restore_command: envdir "{{WALE_ENV_DIR}}" /scripts/restore_command.sh "%f" "%p"
+    restore_command: envdir "{{WALE_ENV_DIR}}" timeout "{{WAL_RESTORE_TIMEOUT}}"
+      /scripts/restore_command.sh "%f" "%p"
   {{/USE_WALE}}
   authentication:
     superuser:
@@ -549,6 +552,7 @@ def get_placeholders(provider):
     placeholders.setdefault('WAL_BUCKET_SCOPE_PREFIX', '{0}-'.format(placeholders['NAMESPACE'])
                             if placeholders['NAMESPACE'] not in ('default', '') else '')
     placeholders.setdefault('WAL_BUCKET_SCOPE_SUFFIX', '')
+    placeholders.setdefault('WAL_RESTORE_TIMEOUT', '0')
     placeholders.setdefault('WALE_ENV_DIR', os.path.join(placeholders['RW_DIR'], 'etc', 'wal-e.d', 'env'))
     placeholders.setdefault('USE_WALE', False)
     cpu_count = str(min(psutil.cpu_count(), 10))


### PR DESCRIPTION
The `restore_command` might not terminate (or at least run for a very long time). This is the case, for instance, if wal-g is enabled and it cannot reach the archive location. See: https://github.com/wal-g/wal-g/issues/1198

This commit adds a timeout for it. If the timeout triggers, then the `restore_command` terminates with exit code 124. PostgreSQL will next try to restore WAL from the `pg_wal` directory, then from the primary server (if configured) and, if that fails, then again from the archive location. See: https://www.postgresql.org/docs/current/warm-standby.html#STANDBY-SERVER-OPERATION

This way, a standby server can, in many (but not all) cases, start even if the archive location is down.

I chose a default `WAL_RESTORE_TIMEOUT` of 16 seconds assuming a transfer rate of at least 1 MB/s. (Note that WAL files are of size 16 MB or less when compressed.) If a user restores from the archive location at a slower rate, then the user must set the `WAL_RESTORE_TIMEOUT` environment variable to an integer larger than `16`.