### PR TITLE
Bump walg to v2.0.0

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -6,7 +6,7 @@ ARG COMPRESS=false
 
 FROM $BASE_IMAGE as dependencies-builder
 
-ENV WALG_VERSION=v1.1
+ENV WALG_VERSION=v2.0.0
 # We want to build ourself non-amd64 wal-g in one of the build steps
 RUN export DEBIAN_FRONTEND=noninteractive \
     && echo 'APT::Install-Recommends "0";\nAPT::Install-Suggests "0";' > /etc/apt/apt.conf.d/01norecommend \


### PR DESCRIPTION
It is worth noting that v2.0 Postgres delta backups are not backward-compatible
with the pre-2.0 versions.