### PR TITLE
Adapt test_spilo.sh for podman

### DIFF
--- a/postgres-appliance/tests/test_spilo.sh
+++ b/postgres-appliance/tests/test_spilo.sh
@@ -2,6 +2,17 @@
 
 cd "$(dirname "${BASH_SOURCE[0]}")" || exit 1
 
+
+if ! docker info &> /dev/null; then
+    if podman info &> /dev/null; then
+        alias docker=podman
+        shopt -s expand_aliases
+    else
+        echo "docker/podman: command not found"
+        exit 1
+    fi
+fi
+
 readonly PREFIX="demo-"
 readonly UPGRADE_SCRIPT="python3 /scripts/inplace_upgrade.py"
 readonly TIMEOUT=120


### PR DESCRIPTION
Create an alias to docker.
As `podman build` tags images in the local registry with a leading `localhost/`, one should run tests with explicitly specified image name (in `SPILO_IMAGE` env variable)