### PR TITLE
Revert changes in upgrade scripts

### DIFF
--- a/postgres-appliance/bootstrap/maybe_pg_upgrade.py
+++ b/postgres-appliance/bootstrap/maybe_pg_upgrade.py
@@ -106,7 +106,7 @@ def main():
     if not upgrade.stop(block_callbacks=True, checkpoint=False):
         raise Exception('Failed to stop the cluster with old postgres')
 
-    if not upgrade.do_upgrade(bin_version):
+    if not upgrade.do_upgrade():
         raise Exception('Failed to upgrade cluster from {0} to {1}'.format(cluster_version, bin_version))
 
     logger.info('Starting the cluster with new postgres after upgrade')

--- a/postgres-appliance/major_upgrade/inplace_upgrade.py
+++ b/postgres-appliance/major_upgrade/inplace_upgrade.py
@@ -506,7 +506,7 @@ hosts deny = *
         except Exception:
             return logger.error('Failed to drop possibly incompatible extensions')
 
-        if not self.postgresql.pg_upgrade(self.desired_version, check=True):
+        if not self.postgresql.pg_upgrade(check=True):
             return logger.error('pg_upgrade --check failed, more details in the %s_upgrade', self.postgresql.data_dir)
 
         try:
@@ -555,7 +555,7 @@ hosts deny = *
             results = pool.map_async(self.checkpoint, self.replica_connections.items())
             pool.close()
 
-        if not self.postgresql.pg_upgrade(self.desired_version):
+        if not self.postgresql.pg_upgrade():
             return logger.error('Failed to upgrade cluster from %s to %s', self.cluster_version, self.desired_version)
 
         self.postgresql.switch_pgdata()

--- a/postgres-appliance/major_upgrade/pg_upgrade.py
+++ b/postgres-appliance/major_upgrade/pg_upgrade.py
@@ -157,7 +157,7 @@ class _PostgresqlUpgrade(Postgresql):
             os.rename(self._data_dir, self._new_data_dir)
         os.rename(self._old_data_dir, self._data_dir)
 
-    def pg_upgrade(self, desired_version, check=False):
+    def pg_upgrade(self, check=False):
         upgrade_dir = self._data_dir + '_upgrade'
         if os.path.exists(upgrade_dir) and os.path.isdir(upgrade_dir):
             shutil.rmtree(upgrade_dir)
@@ -183,9 +183,6 @@ class _PostgresqlUpgrade(Postgresql):
         if subprocess.call([self.pgcommand('pg_upgrade')] + pg_upgrade_args) == 0:
             os.chdir(old_cwd)
             shutil.rmtree(upgrade_dir)
-            # check mode doesn't perform cleanup
-            if check and int(desired_version) >= 15:
-                shutil.rmtree(os.path.join(self._new_data_dir, 'pg_upgrade_output.d'))
             return True
 
     def prepare_new_pgdata(self, version):
@@ -248,8 +245,8 @@ class _PostgresqlUpgrade(Postgresql):
         self.configure_server_parameters()
         return True
 
-    def do_upgrade(self, desired_version):
-        return self.pg_upgrade(desired_version) and self.restore_shared_preload_libraries()\
+    def do_upgrade(self):
+        return self.pg_upgrade() and self.restore_shared_preload_libraries()\
                  and self.switch_pgdata() and self.cleanup_old_pgdata()
 
     def analyze(self, in_stages=False):


### PR DESCRIPTION
base upgrade output directory is now removed  after a successful pg_upgrade --check run