### PR TITLE
Add support for S3 compatible backend to logsender

### DIFF
--- a/ENVIRONMENT.rst
+++ b/ENVIRONMENT.rst
@@ -89,10 +89,13 @@ Environment Configuration Settings
 - **AZURE_CLIENT_SECRET**: (optional) Client secret of the Service Principal
 - **AZURE_TENANT_ID**: (optional) Tenant ID of the Service Principal
 - **CALLBACK_SCRIPT**: the callback script to run on various cluster actions (on start, on stop, on restart, on role change). The script will receive the cluster name, connection string and the current action. See `Patroni <http://patroni.readthedocs.io/en/latest/SETTINGS.html?highlight=callback#postgresql>`__ documentation for details.
-- **LOG_S3_BUCKET**: path to the S3 bucket used for PostgreSQL daily log files (i.e. s3://foobar). Spilo will add /spilo/scope/pg_daily_logs to that path. Logs are shipped if this variable is set.
+- **LOG_S3_BUCKET**: path to the S3 bucket used for PostgreSQL daily log files (i.e. foobar, without `s3://` prefix). Spilo will add `/spilo/{LOG_BUCKET_SCOPE_PREFIX}{SCOPE}{LOG_BUCKET_SCOPE_SUFFIX}/log/` to that path. Logs are shipped if this variable is set.
 - **LOG_SHIP_SCHEDULE**: cron schedule for shipping compressed logs from ``pg_log`` (if this feature is enabled, '00 02 * * *' by default)
 - **LOG_ENV_DIR**: directory to store environment variables necessary for log shipping
 - **LOG_TMPDIR**: directory to store temporary compressed daily log files. PGROOT/../tmp by default.
+- **LOG_S3_ENDPOINT**: (optional) S3 Endpoint to use with Boto3
+- **LOG_BUCKET_SCOPE_PREFIX**: (optional) using to build S3 file path like `/spilo/{LOG_BUCKET_SCOPE_PREFIX}{SCOPE}{LOG_BUCKET_SCOPE_SUFFIX}/log/`
+- **LOG_BUCKET_SCOPE_SUFFIX**: (optional) same as above
 - **DCS_ENABLE_KUBERNETES_API**: a non-empty value forces Patroni to use Kubernetes as a DCS. Default is empty.
 - **KUBERNETES_USE_CONFIGMAPS**: a non-empty value makes Patroni store its metadata in ConfigMaps instead of Endpoints when running on Kubernetes. Default is empty.
 - **KUBERNETES_ROLE_LABEL**: name of the label containing Postgres role when running on Kubernetens. Default is 'spilo-role'.

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -754,7 +754,6 @@ def write_log_environment(placeholders):
         aws_region = placeholders['instance_data']['zone'][:-1]
 
     log_env['LOG_AWS_REGION'] = aws_region
-    log_env['LOG_S3_ENDPOINT'] = log_env.get('LOG_S3_ENDPOINT')
 
     log_s3_key = 'spilo/{LOG_BUCKET_SCOPE_PREFIX}{SCOPE}{LOG_BUCKET_SCOPE_SUFFIX}/log/'.format(**log_env)
     log_s3_key += placeholders['instance_data']['id']

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -581,6 +581,7 @@ def get_placeholders(provider):
 
     placeholders.setdefault('LOG_SHIP_SCHEDULE', '1 0 * * *')
     placeholders.setdefault('LOG_S3_BUCKET', '')
+    placeholders.setdefault('LOG_S3_ENDPOINT', '')
     placeholders.setdefault('LOG_TMPDIR', os.path.abspath(os.path.join(placeholders['PGROOT'], '../tmp')))
     placeholders.setdefault('LOG_BUCKET_SCOPE_SUFFIX', '')
 
@@ -751,7 +752,9 @@ def write_log_environment(placeholders):
     aws_region = log_env.get('AWS_REGION')
     if not aws_region:
         aws_region = placeholders['instance_data']['zone'][:-1]
-    log_env['LOG_AWS_HOST'] = 's3.{}.amazonaws.com'.format(aws_region)
+
+    log_env['LOG_AWS_REGION'] = aws_region
+    log_env['LOG_S3_ENDPOINT'] = log_env.get('LOG_S3_ENDPOINT')
 
     log_s3_key = 'spilo/{LOG_BUCKET_SCOPE_PREFIX}{SCOPE}{LOG_BUCKET_SCOPE_SUFFIX}/log/'.format(**log_env)
     log_s3_key += placeholders['instance_data']['id']
@@ -764,7 +767,7 @@ def write_log_environment(placeholders):
     if not os.path.exists(log_env['LOG_ENV_DIR']):
         os.makedirs(log_env['LOG_ENV_DIR'])
 
-    for var in ('LOG_TMPDIR', 'LOG_AWS_HOST', 'LOG_S3_KEY', 'LOG_S3_BUCKET', 'PGLOG'):
+    for var in ('LOG_TMPDIR', 'LOG_AWS_REGION', 'LOG_S3_ENDPOINT', 'LOG_S3_KEY', 'LOG_S3_BUCKET', 'PGLOG'):
         write_file(log_env[var], os.path.join(log_env['LOG_ENV_DIR'], var), True)
 
 

--- a/postgres-appliance/scripts/upload_pg_log_to_s3.py
+++ b/postgres-appliance/scripts/upload_pg_log_to_s3.py
@@ -55,7 +55,7 @@ def upload_to_s3(local_file_path):
     try:
         bucket.upload_file(local_file_path, key_name, Config=config)
     except S3UploadFailedError as e:
-        logger.exception('Failed to upload the %s to the bucket %s under the key %s. Exception: %s',
+        logger.exception('Failed to upload the %s to the bucket %s under the key %s. Exception: %r',
                          local_file_path, bucket_name, key_name, e)
         return False
 

--- a/postgres-appliance/scripts/upload_pg_log_to_s3.py
+++ b/postgres-appliance/scripts/upload_pg_log_to_s3.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import boto
-import math
+import boto3
 import os
 import logging
 import subprocess
@@ -10,7 +9,9 @@ import sys
 import time
 
 from datetime import datetime, timedelta
-from filechunkio import FileChunkIO
+
+from boto3.exceptions import S3UploadFailedError
+from boto3.s3.transfer import TransferConfig
 
 logger = logging.getLogger(__name__)
 
@@ -37,61 +38,28 @@ def compress_pg_log():
 
 def upload_to_s3(local_file_path):
     # boto picks up AWS credentials automatically when run within a EC2 instance
-
-    # host sets a region and the correct AWS SignatureVersion along the way
-    # see https://github.com/boto/boto/issues/2741
-    conn = boto.connect_s3(host=os.getenv('LOG_AWS_HOST'))
+    s3 = boto3.resource(
+        service_name="s3",
+        endpoint_url=os.getenv('LOG_S3_ENDPOINT'),
+        region_name=os.getenv('LOG_AWS_REGION')
+    )
 
     bucket_name = os.getenv('LOG_S3_BUCKET')
-    bucket = conn.get_bucket(bucket_name, validate=False)
+    bucket = s3.Bucket(bucket_name)
 
     key_name = os.path.join(os.getenv('LOG_S3_KEY'), os.path.basename(local_file_path))
-    mp_upload = bucket.initiate_multipart_upload(key_name)
 
     chunk_size = 52428800  # 50 MiB
-    file_size = os.path.getsize(local_file_path)
-    chunk_count = math.ceil(file_size / chunk_size)
+    config = TransferConfig(multipart_threshold=chunk_size, multipart_chunksize=chunk_size)
 
-    for i in range(chunk_count):
-        offset = chunk_size * i
-        bytes = min(chunk_size, file_size - offset)
-        with FileChunkIO(local_file_path, 'r', offset=offset, bytes=bytes) as fp:
-            try:
-                mp_upload.upload_part_from_file(fp, part_num=i + 1)
-            except Exception:
-                logger.exception('Failed to upload the %s to the bucket %s under the key %s.'
-                                 'Cancelling the multipart upload %s.', local_file_path,
-                                 mp_upload.bucket_name, mp_upload.key_name, mp_upload.id)
-                cancel_multipart_upload(mp_upload)
-                return False
-
-    if not len(mp_upload.get_all_parts()) == chunk_count:
-        cancel_multipart_upload(mp_upload)
+    try:
+        bucket.upload_file(local_file_path, key_name, Config=config)
+    except S3UploadFailedError as e:
+        logger.exception('Failed to upload the %s to the bucket %s under the key %s. Exception: %s',
+                         local_file_path, bucket_name, key_name, e)
         return False
 
-    mp_upload.complete_upload()
     return True
-
-
-def is_successfully_cancelled(mp_upload):
-    return len(mp_upload.bucket.list_multipart_uploads(upload_id_marker=mp_upload.id)) == 0
-
-
-def cancel_multipart_upload(mp_upload, max_retries=3):
-    """
-    Attempt to free storage consumed by already uploaded parts to avoid extra charges from S3.
-    """
-
-    # cancellation might fail for uploads currently in progress
-    for _ in range(max_retries):
-        mp_upload.cancel_upload()
-        if is_successfully_cancelled(mp_upload):
-            break
-        time.sleep(10)
-
-    if not is_successfully_cancelled(mp_upload):
-        logger.warning('Unable to delete some of the already uploaded log parts. '
-                       'Leftover parts incur monetary charges from S3.')
 
 
 def main():


### PR DESCRIPTION
`LOG_S3_ENDPOINT` env variable added to placeholders.

`Multipart_upload` supported natively by boto3 and custom code is no longer needed.
Chunk size passed to the library via `TransferConfig`.
Example taken from [here][1].

`AWS_REGION` populated as `LOG_AWS_REGION` and will be passed to boto3.

[1]: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3.html#multipart-transfers