### PR TITLE
Prefix array_eq with schema to avoid calling overwritten operator.

### DIFF
--- a/postgres-appliance/scripts/post_init.sh
+++ b/postgres-appliance/scripts/post_init.sh
@@ -51,7 +51,7 @@ GRANT SELECT ON TABLE public.pg_auth_mon TO robot_zmon;
 CREATE EXTENSION IF NOT EXISTS pg_cron SCHEMA public;
 DO \$\$
 BEGIN
-    PERFORM 1 FROM pg_catalog.pg_proc WHERE pronamespace = 'cron'::pg_catalog.regnamespace AND proname = 'schedule' AND proargnames = '{p_schedule,p_database,p_command}';
+    PERFORM 1 FROM pg_catalog.pg_proc WHERE pronamespace = 'cron'::pg_catalog.regnamespace AND proname = 'schedule' AND proargnames OPERATOR(pg_catalog.=) '{p_schedule,p_database,p_command}';
     IF FOUND THEN
         ALTER FUNCTION cron.schedule(text, text, text) RENAME TO schedule_in_database;
     END IF;


### PR DESCRIPTION
Previously, a regular user could get superuser role by overwriting `array_eq` operator in public schema:
```sql
create function public.array_eq(text[], text[]) returns boolean
language sql
as $_$
alter user <regular_user> with superuser;
select pg_catalog.array_eq($1, $2);
$_$;
```

When a major version upgrade is triggered or PiTR, the `post_init.sh` is called and since `=` operator is not prefixed with `pg_catalog` the more specific overwritten operator from public schema is called, granting `superuser` role.
More details in [pganalyze blog](https://pganalyze.com/blog/5mins-postgres-security-patch-releases-pgspot-pghostile).
I used [pghostile](https://github.com/aiven/pghostile) to overwrite multiple operators/functions to test.