### PR TITLE
Drop pg_repack before upgrade --check

### DIFF
--- a/postgres-appliance/major_upgrade/pg_upgrade.py
+++ b/postgres-appliance/major_upgrade/pg_upgrade.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 class _PostgresqlUpgrade(Postgresql):
 
-    _INCOMPATIBLE_EXTENSIONS = ('amcheck_next',)
+    _INCOMPATIBLE_EXTENSIONS = ('amcheck_next', 'pg_repack',)
 
     def adjust_shared_preload_libraries(self, version):
         from spilo_commons import adjust_extensions
@@ -96,7 +96,7 @@ class _PostgresqlUpgrade(Postgresql):
                 logger.info('Executing "DROP FUNCTION metric_helpers.pg_stat_statements" in the database="%s"', d)
                 cur.execute("DROP FUNCTION IF EXISTS metric_helpers.pg_stat_statements(boolean) CASCADE")
 
-                for ext in ('pg_stat_kcache', 'pg_stat_statements', 'pg_repack') + self._INCOMPATIBLE_EXTENSIONS:
+                for ext in ('pg_stat_kcache', 'pg_stat_statements') + self._INCOMPATIBLE_EXTENSIONS:
                     logger.info('Executing "DROP EXTENSION IF EXISTS %s" in the database="%s"', ext, d)
                     cur.execute("DROP EXTENSION IF EXISTS {0}".format(ext))
 


### PR DESCRIPTION
There are recent [commits](https://github.com/postgres/postgres/commit/09878cdd489ff7aca761998e7cb104f4fd98ae02) into PG14+ that add an additional check for user-defined objects that refer to internal polymorphic functions with arguments of type "anyarray" or "anyelement". It fails the pg_upgrade check in case such objects are found and requires its deletion first.
pg_repack used to have such functions prior to v1.4.7