### PR TITLE
Multi arch image ci

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         # list of Docker images to use as base name for tags
         images: |
-          ghcr.io/pluralsh/spilo-14
+          ghcr.io/zalando/spilo-14
         # generate Docker tags based on the following events/attributes
         tags: |
           type=ref,event=tag
@@ -43,17 +43,3 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         platforms: linux/amd64,linux/arm64
-  # release:
-  #   name: Create GitHub release
-  #   runs-on: ubuntu-latest
-  #   needs: publish
-  #   permissions:
-  #     contents: write
-  #     discussions: write
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v3
-  #   - name: Release
-  #     uses: softprops/action-gh-release@v1
-  #     with:
-  #       generate_release_notes: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,59 @@
+name: Publish container
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  publish:
+    name: Build and push Spilo container
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+      packages: 'write'
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        # list of Docker images to use as base name for tags
+        images: |
+          ghcr.io/pluralsh/spilo-14
+        # generate Docker tags based on the following events/attributes
+        tags: |
+          type=ref,event=tag
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Login to GHCR
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build and push
+      uses: docker/build-push-action@v3
+      with:
+        context: "postgres-appliance/"
+        file: "postgres-appliance/Dockerfile"
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        platforms: linux/amd64,linux/arm64
+  # release:
+  #   name: Create GitHub release
+  #   runs-on: ubuntu-latest
+  #   needs: publish
+  #   permissions:
+  #     contents: write
+  #     discussions: write
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v3
+  #   - name: Release
+  #     uses: softprops/action-gh-release@v1
+  #     with:
+  #       generate_release_notes: true


### PR DESCRIPTION
It appears that the Zalando registry doesn’t support multi-arch images, which is a big problem for people using mixed architecture nodes in a cluster. This PR adds a workflow that will build a multi-arch image when a new tag is pushed to the repo and push it to GHCR, solving the problem for users with mixed architecture nodes.

The image created by this workflow can be tested at https://github.com/pluralsh/spilo/pkgs/container/spilo-14.

@hughcapet If this workflow is alright with you, I’d be great to have it merged before the new release tag is pushed today. 