### PR TITLE
Fix PiR if (CLONE_)WALG_DOWNLOAD_CONCURRENCY not set

### DIFF
--- a/postgres-appliance/scripts/restore_command.sh
+++ b/postgres-appliance/scripts/restore_command.sh
@@ -48,7 +48,7 @@ if [[ -z $WALE_S3_PREFIX ]]; then  # non AWS environment?
     if [[ -f $wale_prefetch_source ]]; then
         exec mv "${wale_prefetch_source}" "${wal_destination}"
     else
-        exec wal-e wal-fetch -p $POOL_SIZE "${wal_filename}" "${wal_destination}"
+        exec wal-e wal-fetch ${POOL_SIZE:+-p $POOL_SIZE} "${wal_filename}" "${wal_destination}"
     fi
 else
     exec bash /scripts/wal-e-wal-fetch.sh wal-fetch -p $POOL_SIZE "${wal_filename}" "${wal_destination}"

--- a/postgres-appliance/scripts/restore_command.sh
+++ b/postgres-appliance/scripts/restore_command.sh
@@ -51,5 +51,5 @@ if [[ -z $WALE_S3_PREFIX ]]; then  # non AWS environment?
         exec wal-e wal-fetch ${POOL_SIZE:+-p $POOL_SIZE} "${wal_filename}" "${wal_destination}"
     fi
 else
-    exec bash /scripts/wal-e-wal-fetch.sh wal-fetch -p $POOL_SIZE "${wal_filename}" "${wal_destination}"
+    exec bash /scripts/wal-e-wal-fetch.sh wal-fetch ${POOL_SIZE:+-p $POOL_SIZE} "${wal_filename}" "${wal_destination}"
 fi


### PR DESCRIPTION
If WALG_DOWNLOAD_CONCURRENCY env var is not set, restore/clone will fail just after basebackup, while trying to do Point in Time recovery.

POOL_SIZE script variable is set from WALG_DOWNLOAD_CONCURRENCY

Cause for the failure is that restore_command.sh script would call wal-fetch with -p $POOL_SIZE, but as POOL_SIZE has no value, it will fail.

This MR should arrange that "-p" will be used only if POOL_SIZE is defined and is not empty.