### PR TITLE
adds workflow for multiarch builds (linux/amd64, linux/arm64) being published to ghcr.io

### DIFF
--- a/.github/workflows/publish-ghcr-container.yaml
+++ b/.github/workflows/publish-ghcr-container.yaml
@@ -1,0 +1,65 @@
+name: Publish multiarch images on ghcr.io
+on:
+  push:
+    tags:
+      - '*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  publish:
+    name: Build and push Spilo multiarch images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      packages: 'write'
+    defaults:
+      run:
+        shell: bash
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Derive spilo image name
+      id: image
+      working-directory: postgres-appliance
+      run: |
+        PGVERSION=$(sed -n 's/^ARG PGVERSION=\([1-9][0-9]*\).*$/\1/p' Dockerfile)
+        IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-$PGVERSION:${GITHUB_REF/refs\/tags\//}"
+        echo "::set-output name=NAME::$IMAGE"
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Login to GHCR
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and export to local docker for testing
+      uses: docker/build-push-action@v3
+      with:
+        context: "postgres-appliance/"
+        load: true
+        tags: ${{ steps.image.outputs.NAME }}
+
+    - name: Test spilo docker image 
+      env:
+        SPILO_IMAGE: "${{ steps.image.outputs.NAME }}"
+      run: |
+        bash postgres-appliance/tests/test_spilo.sh 
+
+    - name: Build arm64 additionaly and push multiarch image to ghcr
+      uses: docker/build-push-action@v3
+      with:
+        context: "postgres-appliance/"
+        push: true
+        tags: "${{ steps.image.outputs.NAME }}"
+        platforms: linux/amd64,linux/arm64

--- a/.github/workflows/publish-ghcr-container.yaml
+++ b/.github/workflows/publish-ghcr-container.yaml
@@ -22,6 +22,14 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+
+    - name: Install flake8 and docker-compose
+      run: python -m pip install flake8 docker-compose==1.17.1
+
     - name: Derive spilo image name
       id: image
       working-directory: postgres-appliance

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
-    - name: Install flake8
+    - name: Install flake8 and docker-compose
       run: python -m pip install flake8 docker-compose==1.17.1
     - name: Run shellcheck
       run: find postgres-appliance -name '*.sh' -print0 | xargs -0 shellcheck

--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,14 @@ How to Use This Docker Image
 
 Spilo's setup assumes that you've correctly configured a load balancer (HAProxy, ELB, Google load balancer) that directs client connections to the master. There are two ways to achieve this: A) if the load balancer relies on the status code to distinguish between the healthy and failed nodes (like ELB), then one needs to configure it to poll the API URL; otherwise, B) you can use callback scripts to change the load balancer configuration dynamically.
 
+**Available container registries and image architectures**
+
+Spilo images are made available in two registries. First our publicly available opensource registry (a) and second the GitHub Container registry (b). Our internal registry is our preferred registry and is used as default by our postgres-operator. However, since our internal registry is not yet capable of mutliarch images and manifest lists, we additionally build and publish linux/amd64 and linux/arm64 images on the repos container registry.
+
+a) linux/amd64 only: registry.opensource.zalan.do/acid/spilo-$PGVERSION:$TAG
+b) linux/amd64 and linux/arm64: ghcr.io/zalando/spilo-$PGVERSION:$TAG
+
+
 How to Build This Docker Image
 ==============================
 

--- a/postgres-appliance/tests/README
+++ b/postgres-appliance/tests/README
@@ -1,0 +1,5 @@
+# Spilo Test
+
+## docker-compose.yml
+The spilo image to be tested can be defined using the environment variable `SPILO_IMAGE`.
+If ommitted it will default to `spilo`.

--- a/postgres-appliance/tests/docker-compose.yml
+++ b/postgres-appliance/tests/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         command: -c 'mkdir -p /export/testbucket && /usr/bin/minio server /export'
 
     etcd:
-        image: spilo
+        image: ${SPILO_IMAGE:-spilo}
         networks: [ demo ]
         container_name: demo-etcd
         hostname: etcd
@@ -24,7 +24,7 @@ services:
 
     spilo1: &spilo
         depends_on: [ minio ]
-        image: spilo
+        image: ${SPILO_IMAGE:-spilo}
         networks: [ demo ]
         environment:
             SPILO_PROVIDER: 'local'


### PR DESCRIPTION
### Changelog

- introduces new GHA workflow to build and publish spilo multiarch images on ghcr.io. Workflow is triggered on tag creation.
- currently linux/amd64 and linux/arm64 images are built
- linux/amd64 build is tested using postgres-appliance/tests/test_spilo.sh
- **Note** the linux/arm64 takes much more time, due to emulation, then the linux/amd64 build (7 vs. 120min)

### Changes

- adds GHA workflow .github/workflows/publish-ghcr-container.yaml
- extends postgres-appliance/tests/docker-compose.yml to allow spilo image definition using environment variable, cf. postgres-appliance/tests/README
- adds small section in the README mentioning that multiarch builds can be found on ghcr.io

### Tests

Tests were done by tagging the forked repo. Tag `p1-2` was successful.

- workflow run can be found here: https://github.com/mmoscher/spilo/actions/runs/3245461373/jobs/5323031631
- multiarch images can be found here:

### Follow-Up:

- wal-g multiarch builds are now available. Thus, https://github.com/zalando/spilo/pull/664 can be reverted and additional self-builds can be omitted. Finally, the arm64 build-time should decrease enormously. 