### PR TITLE
PyYAML 6.0 compatibility

### DIFF
--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -997,7 +997,7 @@ def write_crontab(placeholders, overwrite):
         lines += [('{LOG_SHIP_SCHEDULE} nice -n 5 envdir "{LOG_ENV_DIR}"' +
                    ' /scripts/upload_pg_log_to_s3.py').format(**placeholders)]
 
-    lines += yaml.load(placeholders['CRONTAB'])
+    lines += yaml.load(placeholders['CRONTAB'], Loader=yaml.SafeLoader)
 
     if len(lines) > 1 or root_lines:
         setup_runit_cron(placeholders)
@@ -1053,10 +1053,11 @@ def main():
     placeholders = get_placeholders(provider)
     logging.info('Looks like you are running %s', provider)
 
-    config = yaml.load(pystache_render(TEMPLATE, placeholders))
+    config = yaml.load(pystache_render(TEMPLATE, placeholders), Loader=yaml.SafeLoader)
     config.update(get_dcs_config(config, placeholders))
 
-    user_config = yaml.load(os.environ.get('SPILO_CONFIGURATION', os.environ.get('PATRONI_CONFIGURATION', ''))) or {}
+    user_config = yaml.load(os.environ.get('SPILO_CONFIGURATION', os.environ.get('PATRONI_CONFIGURATION', '')),
+                            Loader=yaml.SafeLoader) or {}
     if not isinstance(user_config, dict):
         config_var_name = 'SPILO_CONFIGURATION' if 'SPILO_CONFIGURATION' in os.environ else 'PATRONI_CONFIGURATION'
         raise ValueError('{0} should contain a dict, yet it is a {1}'.format(config_var_name, type(user_config)))


### PR DESCRIPTION
Version 6.0 of PyYAML requires a Loader parameter for yaml.load.

Defaulting to SafeLoader for good hygiene, previous behavior was to use FullLoader.