### PR TITLE
remove redundant privilege escalation check for sys_nice capability

### DIFF
--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -973,13 +973,9 @@ def write_crontab(placeholders, overwrite):
 
     if sys_nice_is_set:
         renice = '*/5 * * * * bash /scripts/renice.sh'
-        if not no_new_privs:
-            lines += [renice]
-        elif os.getuid() == 0:
+        lines += [renice]
+        if os.getuid() == 0:
             root_lines = [lines[0], renice]
-        else:
-            logging.info('Skipping creation of renice cron job due to running as not root '
-                         'and with "no-new-privileges:true" (allowPrivilegeEscalation=false on K8s)')
     else:
         logging.info('Skipping creation of renice cron job due to lack of SYS_NICE capability')
 


### PR DESCRIPTION
There is a check on 'no_new_privs' flag while this seems not necessary to run renice.sh script if the SYS_NICE capability is set which is already checked in the script. 

Removed this redundant check so the renice crontab can be created if the necessary capabilities are set. 
