### PR TITLE
add function to list last status of active cron jobs

### DIFF
--- a/postgres-appliance/scripts/metric_helpers.sql
+++ b/postgres-appliance/scripts/metric_helpers.sql
@@ -83,15 +83,7 @@ FROM (
 ) AS s3 WHERE schemaname NOT LIKE 'information_schema';
 $_$ LANGUAGE sql SECURITY DEFINER IMMUTABLE STRICT SET search_path to 'pg_catalog';
 
-REVOKE ALL ON FUNCTION get_table_bloat_approx() FROM public;
-GRANT EXECUTE ON FUNCTION get_table_bloat_approx() TO admin;
-GRANT EXECUTE ON FUNCTION get_table_bloat_approx() TO robot_zmon;
-
 CREATE OR REPLACE VIEW table_bloat AS SELECT * FROM get_table_bloat_approx();
-
-REVOKE ALL ON TABLE table_bloat FROM public;
-GRANT SELECT ON TABLE table_bloat TO admin;
-GRANT SELECT ON TABLE table_bloat TO robot_zmon;
 
 CREATE OR REPLACE FUNCTION get_btree_bloat_approx (
     OUT i_database name,
@@ -193,30 +185,14 @@ FROM (
 ) AS relation_stats;
 $_$ LANGUAGE sql SECURITY DEFINER IMMUTABLE STRICT SET search_path to 'pg_catalog';
 
-REVOKE ALL ON FUNCTION get_btree_bloat_approx() FROM public;
-GRANT EXECUTE ON FUNCTION get_btree_bloat_approx() TO admin;
-GRANT EXECUTE ON FUNCTION get_btree_bloat_approx() TO robot_zmon;
-
 CREATE OR REPLACE VIEW index_bloat AS SELECT * FROM get_btree_bloat_approx();
-
-REVOKE ALL ON TABLE index_bloat FROM public;
-GRANT SELECT ON TABLE index_bloat TO admin;
-GRANT SELECT ON TABLE index_bloat TO robot_zmon;
 
 CREATE OR REPLACE FUNCTION pg_stat_statements(showtext boolean) RETURNS SETOF public.pg_stat_statements AS
 $$
   SELECT * FROM public.pg_stat_statements(showtext);
 $$ LANGUAGE sql IMMUTABLE SECURITY DEFINER STRICT;
 
-REVOKE ALL ON FUNCTION pg_stat_statements(boolean) FROM public;
-GRANT EXECUTE ON FUNCTION pg_stat_statements(boolean) TO admin;
-GRANT EXECUTE ON FUNCTION pg_stat_statements(boolean) TO robot_zmon;
-
 CREATE OR REPLACE VIEW pg_stat_statements AS SELECT * FROM pg_stat_statements(true);
-
-REVOKE ALL ON TABLE pg_stat_statements FROM public;
-GRANT SELECT ON TABLE pg_stat_statements TO admin;
-GRANT SELECT ON TABLE pg_stat_statements TO robot_zmon;
 
 CREATE FUNCTION get_last_status_active_cronjobs(
   OUT jobid bigint,
@@ -242,5 +218,15 @@ SELECT DISTINCT ON (job_run_details.jobid)
  ORDER BY job_run_details.jobid, job_run_details.start_time DESC NULLS LAST;
 $_$
 LANGUAGE sql SECURITY DEFINER STRICT SET search_path to 'cron';
+
+CREATE OR REPLACE VIEW status_active_cronjobs AS SELECT * FROM get_last_status_active_cronjobs();
+
+REVOKE ALL ON ALL TABLES IN SCHEMA metric_helpers FROM public;
+GRANT SELECT ON ALL TABLES IN SCHEMA metric_helpers TO admin;
+GRANT SELECT ON ALL TABLES IN SCHEMA metric_helpers TO robot_zmon;
+
+REVOKE ALL ON ALL FUNCTIONS IN SCHEMA metric_helpers FROM public;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA metric_helpers TO admin;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA metric_helpers TO robot_zmon;
 
 RESET search_path;

--- a/postgres-appliance/scripts/metric_helpers.sql
+++ b/postgres-appliance/scripts/metric_helpers.sql
@@ -219,7 +219,7 @@ SELECT DISTINCT ON (job_run_details.jobid)
 $_$
 LANGUAGE sql SECURITY DEFINER STRICT SET search_path to 'cron';
 
-CREATE OR REPLACE VIEW status_active_cronjobs AS SELECT * FROM get_last_status_active_cronjobs();
+CREATE OR REPLACE VIEW last_status_active_cronjobs AS SELECT * FROM get_last_status_active_cronjobs();
 
 REVOKE ALL ON ALL TABLES IN SCHEMA metric_helpers FROM public;
 GRANT SELECT ON ALL TABLES IN SCHEMA metric_helpers TO admin;


### PR DESCRIPTION
We want to alert on failing cron jobs. But `robot_zmon` user has no rights to query tables cron.job and cron.job_run_details. Even when granted USAGE and SELECT, the details are protected by a [row level policy](https://github.com/zalando/spilo/blob/master/postgres-appliance/scripts/post_init.sh#L61). Therefore, the PR suggests to add a wrapper function with SECURITY DEFINER to allow the invoker to list the last status of active cron jobs.