### PR TITLE
Enforce search_path=pg_catalog

### DIFF
--- a/postgres-appliance/scripts/on_role_change.sh
+++ b/postgres-appliance/scripts/on_role_change.sh
@@ -10,7 +10,7 @@ readonly dbname=postgres
 if [[ "${*: -3:1}" == "on_role_change" && "${*: -2:1}" == "master" ]]; then
     num=30  # wait 30 seconds for end of recovery
     while  [[ $((num--)) -gt 0 ]]; do
-        if [[ "$(psql -d $dbname -tAc 'SELECT pg_is_in_recovery()')" == "f" ]]; then
+        if [[ "$(psql -d $dbname -tAc 'SELECT pg_catalog.pg_is_in_recovery()')" == "f" ]]; then
             vacuumdb -aZ > /dev/null 2>&1 &
             exec /scripts/post_init.sh "$HUMAN_ROLE" "$dbname"
         else

--- a/postgres-appliance/scripts/post_init.sh
+++ b/postgres-appliance/scripts/post_init.sh
@@ -2,6 +2,8 @@
 
 cd "$(dirname "${BASH_SOURCE[0]}")" || exit 1
 
+export PGOPTIONS="-c synchronous_commit=local -c search_path=pg_catalog"
+
 PGVER=$(psql -d "$2" -XtAc "SELECT pg_catalog.current_setting('server_version_num')::int/10000")
 if [ "$PGVER" -ge 12 ]; then RESET_ARGS="oid, oid, bigint"; fi
 
@@ -203,4 +205,4 @@ GRANT EXECUTE ON FUNCTION public.pg_stat_statements_reset($RESET_ARGS) TO admin;
     if [ "$ENABLE_PG_MON" = "true" ] && [ "$PGVER" -ge 11 ]; then echo "CREATE EXTENSION IF NOT EXISTS pg_mon SCHEMA public;"; fi
     cat metric_helpers.sql
 done < <(psql -d "$2" -tAc 'select pg_catalog.quote_ident(datname) from pg_catalog.pg_database where datallowconn')
-) | PGOPTIONS="-c synchronous_commit=local" psql -Xd "$2"
+) | psql -Xd "$2"

--- a/postgres-appliance/scripts/postgres_backup.sh
+++ b/postgres-appliance/scripts/postgres_backup.sh
@@ -13,7 +13,7 @@ log "I was called as: $0 $*"
 readonly PGDATA=$1
 DAYS_TO_RETAIN=$BACKUP_NUM_TO_RETAIN
 
-IN_RECOVERY=$(psql -tXqAc "select pg_is_in_recovery()")
+IN_RECOVERY=$(psql -tXqAc "select pg_catalog.pg_is_in_recovery()")
 readonly IN_RECOVERY
 if [[ $IN_RECOVERY == "f" ]]; then
     [[ "$WALG_BACKUP_FROM_REPLICA" == "true" ]] && log "Cluster is not in recovery, not running backup" && exit 0

--- a/postgres-appliance/scripts/wale_restore.sh
+++ b/postgres-appliance/scripts/wale_restore.sh
@@ -4,6 +4,8 @@ RETRIES=2
 THRESHOLD_PERCENTAGE=30
 THRESHOLD_MEGABYTES=10240
 
+export PGOPTIONS="-c search_path=pg_catalog"
+
 while getopts ":-:" optchar; do
     [[ "${optchar}" == "-" ]] || continue
     case "${OPTARG}" in


### PR DESCRIPTION
- Enforce search_path=pg_catalog for post_init and wale_restore scripts
- call `pg_is_in_recovery()` with schema in several places

the problem was raised in https://github.com/zalando/spilo/pull/771