### PR TITLE
Increase cdp pipeline timeout

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -13,7 +13,7 @@ pipeline:
     - event: push
       branch: master
     - event: pull_request
-  timeout: 3h
+  timeout: 10h
   vm_config:
     type: linux
     size: extra_large


### PR DESCRIPTION
Set `build-spilo-cdp` step's timeout to 10h