### PR TITLE
Patroni 3.0.2 and timescaledb 2.10.1

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=ubuntu:22.04
 ARG PGVERSION=15
-ARG TIMESCALEDB="1.7.5 2.3.1 2.10.0"
+ARG TIMESCALEDB="1.7.5 2.3.1 2.10.1"
 ARG DEMO=false
 ARG COMPRESS=false
 ARG ADDITIONAL_LOCALES=
@@ -76,7 +76,7 @@ COPY --from=dependencies-builder /builddeps/wal-g /usr/local/bin/
 COPY build_scripts/patroni_wale.sh build_scripts/compress_build.sh /builddeps/
 
 # Install patroni and wal-e
-ENV PATRONIVERSION=3.0.1
+ENV PATRONIVERSION=3.0.2
 ENV WALE_VERSION=1.1.1
 
 WORKDIR /


### PR DESCRIPTION
- Patroni release notes: https://github.com/zalando/patroni/blob/master/docs/releases.rst#version-302

- Timescaledb release notes: https://github.com/timescale/timescaledb/releases/tag/2.10.1

> This release contains bug fixes since the 2.10.0 release.
We recommend that you upgrade at the next available opportunity.