### PR TITLE
Full support of timescaledb for pg15

### DIFF
--- a/postgres-appliance/scripts/spilo_commons.py
+++ b/postgres-appliance/scripts/spilo_commons.py
@@ -12,7 +12,7 @@ LIB_DIR = '/usr/lib/postgresql'
 
 # (min_version, max_version, shared_preload_libraries, extwlist.extensions)
 extensions = {
-    'timescaledb':    (9.6, 14, True,  True),
+    'timescaledb':    (9.6, 15, True,  True),
     'pg_cron':        (9.5, 15, True,  False),
     'pg_stat_kcache': (9.4, 15, True,  False),
     'pg_partman':     (9.4, 15, False, True)

--- a/postgres-appliance/tests/test_spilo.sh
+++ b/postgres-appliance/tests/test_spilo.sh
@@ -346,11 +346,11 @@ function test_spilo() {
     log_info "Started $basebackup_container for testing major upgrade 11->12 after clone with basebackup"
 
     # TEST SUITE 1
-    run_test test_pg_upgrade_to_15_check_failed "$container"  # pg_upgrade --check complains about timescaledb
+    # run_test test_pg_upgrade_to_15_check_failed "$container"  # pg_upgrade --check complains about timescaledb
 
     wait_backup "$container"
 
-    drop_timescaledb "$container"
+    # drop_timescaledb "$container"
 
     log_info "Testing in-place major upgrade to 14->15"
     run_test test_successful_inplace_upgrade_to_15 "$container"


### PR DESCRIPTION
Change the max PG version which provides timescaledb in shared_preload_libraries and extwlist.extensions to 15