### PR TITLE
Don't reset defaults in the pgq_ticker.ini

### DIFF
--- a/postgres-appliance/pgq_ticker.ini
+++ b/postgres-appliance/pgq_ticker.ini
@@ -2,6 +2,6 @@
 initial_database = postgres
 
 # how often to do maintentance, in seconds.
-maint_period = 600
+maint_period = 120
 # how often to run ticker, in seconds.
-ticker_period = 60
+ticker_period = 1


### PR DESCRIPTION
As we had pgq daemon using the defaults for a long time, let's avoid an unexpected change of behaviour in pgq processing 