### PR TITLE
Fix ssl.SSLError: [SSL: HTTP_REQUEST] http request (_ssl.c:997) in Sp…

### DIFF
--- a/postgres-appliance/runit/pgqd/run
+++ b/postgres-appliance/runit/pgqd/run
@@ -6,4 +6,4 @@ if ! $CHPST true 2> /dev/null; then
 fi
 
 exec 2>&1
-exec $CHPST env -i PGAPPNAME="pgq ticker" /scripts/patroni_wait.sh --role master -- /usr/bin/pgqd /home/postgres/pgq_ticker.ini
+exec $CHPST env -i PGAPPNAME="pgq ticker" SSL_RESTAPI_CERTIFICATE_FILE="$SSL_RESTAPI_CERTIFICATE_FILE" SSL_RESTAPI_PRIVATE_KEY_FILE="$SSL_RESTAPI_PRIVATE_KEY_FILE" SSL_RESTAPI_CA_FILE="$SSL_RESTAPI_CA_FILE" /scripts/patroni_wait.sh --role master -- /usr/bin/pgqd /home/postgres/pgq_ticker.ini


### PR DESCRIPTION
Hi Team,

I opened the following issue:
https://github.com/zalando/spilo/issues/889

that explain a problem I found on Spilo 3.0-p1 code.  In September 2021 I submitted two PRs to add SSL support to Patroni:
https://github.com/zalando/spilo/pull/629
https://github.com/zalando/spilo/pull/625

however, I found out that the file ```postgres-appliance/scripts/patroni_wait.sh``` doesn't manage SSL variable so an error message appear at startup if patroni is configured in SSL (see my issue above). I had a discussion with Alexander Kukushkin on Slack and we agreed a possible solution. This solution, at the moment, is already running in my company dev, staging and production systems with an external patch I applied to Spilo 3.0-p1 during our build.

However, I would like to have this fix in the official code.
 