### PR TITLE
feat(wale-clone): Added data dir permission change (0700) during cloning

### DIFF
--- a/postgres-appliance/bootstrap/clone_with_wale.py
+++ b/postgres-appliance/bootstrap/clone_with_wale.py
@@ -176,6 +176,10 @@ def run_clone_from_s3(options):
             envdir = get_clone_envdir()
             with open(os.path.join(envdir, update_envdir), 'w') as f:
                 f.write(env[update_envdir])
+        
+        ret = subprocess.call(['chmod', '0700', options.datadir])
+        if ret != 0:
+            raise Exception("Permission adjustment of data dir exited with code {0}".format(ret))
     return 0
 
 


### PR DESCRIPTION
In the `launch.sh` script, the permissions of PGROOT and PGDATA directories are already set. In situations where you clone an instance from a source with wrong permissions (e.g. `0775`) on the PGDATA directory, the clone will fail during recovery, since the permissions will be set wrong.

The error will be something like this:
```
data directory "/home/postgres/pgdata/pgroot/data" has invalid permissions
DETAIL:  Permissions should be u=rwx (0700) or u=rwx,g=rx (0750).
```

This PR includes setting the permissions to `0700` of the PGDATA directory after the `backup-fetch` has been done. The actual instance recovery will therefore not fail.

I hope you find this helpful.

Kind regards
Philip