### PR TITLE
Multiarch ppc64le support

### DIFF
--- a/.github/workflows/publish-ghcr-container.yaml
+++ b/.github/workflows/publish-ghcr-container.yaml
@@ -70,4 +70,4 @@ jobs:
         context: "postgres-appliance/"
         push: true
         tags: "${{ steps.image.outputs.NAME }}"
-        platforms: linux/amd64,linux/arm64
+        platforms: linux/amd64,linux/arm64,linux/ppc64le


### PR DESCRIPTION
*The multiarch image build has been performed successfully (locally) in an Intel Ubuntu 22.04 container.
*A recent version of the Spilo image has been tested on a production ppc64le Openshift cluster.