### PR TITLE
Update /usr/bin/env to python3 (python not found).

### DIFF
--- a/postgres-appliance/bootstrap/clone_with_basebackup.py
+++ b/postgres-appliance/bootstrap/clone_with_basebackup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import logging

--- a/postgres-appliance/bootstrap/clone_with_wale.py
+++ b/postgres-appliance/bootstrap/clone_with_wale.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import csv

--- a/postgres-appliance/bootstrap/maybe_pg_upgrade.py
+++ b/postgres-appliance/bootstrap/maybe_pg_upgrade.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import datetime
 import logging
 import os

--- a/postgres-appliance/major_upgrade/inplace_upgrade.py
+++ b/postgres-appliance/major_upgrade/inplace_upgrade.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import json
 import logging
 import os

--- a/postgres-appliance/scripts/callback_aws.py
+++ b/postgres-appliance/scripts/callback_aws.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import boto.ec2
 import boto.utils

--- a/spilo_cmd/setup.py
+++ b/spilo_cmd/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """


### PR DESCRIPTION
A few of the python scripts in postgres-appliance and spilo_cmd contain "#!/usr/bin/env python" and a few contain "#!/usr/bin/env python3".  I noticed cloning (via /scripts/clone_with_wale.py) fails silently, so investigating further showed "/usr/bin/env: ‘python’: No such file or directory" when run with appropriate envdir.

I suspect these should be updated to explicitly select python3, and quick testing shows that resolves the issue (scripts provide usage information instead of the above "No such file or directory" error).