### PR TITLE
Update available extensions for pg16

### DIFF
--- a/postgres-appliance/build_scripts/base.sh
+++ b/postgres-appliance/build_scripts/base.sh
@@ -174,7 +174,7 @@ for version in $DEB_PG_SUPPORTED_VERSIONS; do
     EXTRA_EXTENSIONS=()
     if [ "$DEMO" != "true" ]; then
         if [ "$version" != "16" ]; then
-            EXTRA_EXTENSIONS+=("plantuner-${PLANTUNER_COMMIT}" plprofiler)
+            EXTRA_EXTENSIONS+=("plantuner-${PLANTUNER_COMMIT}" plprofiler "pg_tm_aux-${PG_TM_AUX_COMMIT}")
         fi
         if [ "${version%.*}" -ge 10 ]; then
             EXTRA_EXTENSIONS+=("pg_mon-${PG_MON_COMMIT}")
@@ -185,7 +185,6 @@ for version in $DEB_PG_SUPPORTED_VERSIONS; do
             pg_auth_mon-${PG_AUTH_MON_COMMIT} \
             set_user \
             pg_permissions-${PG_PERMISSIONS_COMMIT} \
-            pg_tm_aux-${PG_TM_AUX_COMMIT} \
             pg_profile-${PG_PROFILE} \
             "${EXTRA_EXTENSIONS[@]}"; do
         make -C "$n" USE_PGXS=1 clean install-strip

--- a/postgres-appliance/build_scripts/base.sh
+++ b/postgres-appliance/build_scripts/base.sh
@@ -139,18 +139,20 @@ for version in $DEB_PG_SUPPORTED_VERSIONS; do
     # use subshell to avoid having to cd back (SC2103)
     (
         cd timescaledb
-        for v in $TIMESCALEDB; do
-            git checkout "$v"
-            sed -i "s/VERSION 3.11/VERSION 3.10/" CMakeLists.txt
-            if BUILD_FORCE_REMOVE=true ./bootstrap -DREGRESS_CHECKS=OFF -DWARNINGS_AS_ERRORS=OFF \
-                    -DTAP_CHECKS=OFF -DPG_CONFIG="/usr/lib/postgresql/$version/bin/pg_config" \
-                    -DAPACHE_ONLY="$TIMESCALEDB_APACHE_ONLY" -DSEND_TELEMETRY_DEFAULT=NO; then
-                make -C build install
-                strip /usr/lib/postgresql/"$version"/lib/timescaledb*.so
-            fi
-            git reset --hard
-            git clean -f -d
-        done
+        if [ "$version" != "16 " ]; then
+            for v in $TIMESCALEDB; do
+                git checkout "$v"
+                sed -i "s/VERSION 3.11/VERSION 3.10/" CMakeLists.txt
+                if BUILD_FORCE_REMOVE=true ./bootstrap -DREGRESS_CHECKS=OFF -DWARNINGS_AS_ERRORS=OFF \
+                        -DTAP_CHECKS=OFF -DPG_CONFIG="/usr/lib/postgresql/$version/bin/pg_config" \
+                        -DAPACHE_ONLY="$TIMESCALEDB_APACHE_ONLY" -DSEND_TELEMETRY_DEFAULT=NO; then
+                    make -C build install
+                    strip /usr/lib/postgresql/"$version"/lib/timescaledb*.so
+                fi
+                git reset --hard
+                git clean -f -d
+            done
+        fi
     )
 
     if [ "${TIMESCALEDB_APACHE_ONLY}" != "true" ] && [ "${TIMESCALEDB_TOOLKIT}" = "true" ]; then


### PR DESCRIPTION
new extensions update:
* plproxy
* partman
* pglogical
* pglogical-ticker
* plpgsql-check

still unavailable:
* pgl-ddl-deploy 
* plantuner
* plprofiler
* timescaledb