### PR TITLE
Add errorhandling for ulimit

### DIFF
--- a/postgres-appliance/runit/patroni/run
+++ b/postgres-appliance/runit/patroni/run
@@ -21,7 +21,6 @@ fi
 if ! ulimit -c unlimited
 then
    echo "Failed to set unlimited size for coredump"
-   echo "Consider adding the SYS_RESOURCE capability"
 fi
 
 # Only small subset of environment variables is allowed. We don't want accidentally disclose sensitive information


### PR DESCRIPTION
In case the container is not spawned with `SYS_RESOURCE`, setting unlimited size for coredumps will never work.
Since the defaults in the script is to abort on any uncaught errors - I propose we catch the `ulimit` error, and notify the user about the possible missing capability.

This fixes issues like https://github.com/zalando/postgres-operator/issues/2387