### PR TITLE
Remove amcheck_next installation, removal

### DIFF
--- a/postgres-appliance/major_upgrade/pg_upgrade.py
+++ b/postgres-appliance/major_upgrade/pg_upgrade.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 class _PostgresqlUpgrade(Postgresql):
 
-    _INCOMPATIBLE_EXTENSIONS = ('amcheck_next', 'pg_repack',)
+    _INCOMPATIBLE_EXTENSIONS = ('pg_repack',)
 
     def adjust_shared_preload_libraries(self, version):
         from spilo_commons import adjust_extensions

--- a/postgres-appliance/tests/schema.sql
+++ b/postgres-appliance/tests/schema.sql
@@ -1,5 +1,4 @@
-CREATE EXTENSION pg_repack;
-CREATE EXTENSION amcheck_next;  /* the upgrade script must delete it before running pg_upgrade --check! */
+CREATE EXTENSION pg_repack; /* the upgrade script must delete it before running pg_upgrade --check! */
 
 CREATE DATABASE test_db;
 \c test_db


### PR DESCRIPTION
There is no amcheck_next anymore, as we dropped PG10 support.