### PR TITLE
No pg_partman update from <5.X during major upgrade

### DIFF
--- a/postgres-appliance/major_upgrade/pg_upgrade.py
+++ b/postgres-appliance/major_upgrade/pg_upgrade.py
@@ -121,6 +121,9 @@ class _PostgresqlUpgrade(Postgresql):
                 for extname, version in cur.fetchall():
                     # require manual update to 5.X+
                     if extname == 'pg_partman' and int(version[0]) < 5:
+                        logger.warning("Skipping update of '%s' in database=%s. "
+                                       "Extension version: %s. Consider manual update",
+                                       extname, d, version)
                         continue
                     query = 'ALTER EXTENSION {0} UPDATE'.format(extname)
                     logger.info("Executing '%s' in the database=%s", query, d)


### PR DESCRIPTION
Due to the noticeable number of backward-incompatible changes in pg_parman 5.0, we better force users to prepare and check everything before actually upgrading the extension. So if performing major upgrade with pg_partman pre 5.X installed, we skip automatic update of it