### PR TITLE
fix(clone_with_wale): fix script to work with wal-g master

### DIFF
--- a/postgres-appliance/bootstrap/clone_with_wale.py
+++ b/postgres-appliance/bootstrap/clone_with_wale.py
@@ -57,9 +57,10 @@ def fix_output(output):
     started = None
     for line in output.decode('utf-8').splitlines():
         if not started:
-            started = re.match(r'^name\s+last_modified\s+', line) or re.match(r'^name\s+modified\s+', line)
+            started = re.match(r'^name\s+last_modified\s+', line) or re.match(r'^name\s+modified\s+', line) or re.match(r'^backup_name\s+modified\s+', line)
             if started:
                 line = line.replace(' modified ', ' last_modified ')
+                line = line.replace(' backup_name ', ' name ')
         if started:
             yield '\t'.join(line.split())
 


### PR DESCRIPTION
While working with a wal-g binary built from master branch and spilo, I found out that the newer version of wal-g uses `backup_name` instead of `name` in the output of the command, this change make the script not functional during a restore operation.

The change is pretty straightforward, it's also needed to replace the `backup_name` word to `name` to keep everything together and to support also older versions of wal-g.