### PR TITLE
Spilo build is failing fix dependencies.sh due to error at WAL-G 

### DIFF
--- a/postgres-appliance/build_scripts/dependencies.sh
+++ b/postgres-appliance/build_scripts/dependencies.sh
@@ -35,6 +35,10 @@ go get -v -t -d ./...
 go mod vendor
 
 bash link_brotli.sh
+
+sed -i -e 's/1.0.17/1.0.18/g' link_libsodium.sh
+sed -i -e 's/download\/$LIBSODIUM_VERSION/download\/$LIBSODIUM_VERSION-RELEASE/g' link_libsodium.sh
+
 bash link_libsodium.sh
 
 export USE_LIBSODIUM=1

--- a/postgres-appliance/build_scripts/dependencies.sh
+++ b/postgres-appliance/build_scripts/dependencies.sh
@@ -37,7 +37,7 @@ go mod vendor
 bash link_brotli.sh
 
 sed -i -e 's/1.0.17/1.0.18/g' link_libsodium.sh
-sed -i -e 's/download\/$LIBSODIUM_VERSION/download\/$LIBSODIUM_VERSION-RELEASE/g' link_libsodium.sh
+sed -i -e "s/download\/\$LIBSODIUM_VERSION/download\/\$LIBSODIUM_VERSION-RELEASE/g" link_libsodium.sh
 
 bash link_libsodium.sh
 


### PR DESCRIPTION
Libsodium release link is updated as older one is no longer valid and Spilo build fails.

### Logs
```
98.94 + bash link_libsodium.sh
99.22 
99.22 gzip: stdin: not in gzip format
99.22 tar: Child returned status 1
99.22 tar: Error is not recoverable: exiting now
```

This is quickfix  as of now i have already another PR for root cause in WAL-g itself
https://github.com/wal-g/wal-g/pull/1740
