### PR TITLE
Install wal-g from a precompiled bin

### DIFF
--- a/postgres-appliance/build_scripts/dependencies.sh
+++ b/postgres-appliance/build_scripts/dependencies.sh
@@ -18,36 +18,22 @@ MAKEFLAGS="-j $(grep -c ^processor /proc/cpuinfo)"
 export MAKEFLAGS
 ARCH="$(dpkg --print-architecture)"
 
+# We want to remove all libgdal30 debs except one that is for current architecture.
+printf "shopt -s extglob\nrm /builddeps/!(*_%s.deb)" "$ARCH" | bash -s
+
 echo -e 'APT::Install-Recommends "0";\nAPT::Install-Suggests "0";' > /etc/apt/apt.conf.d/01norecommend
 
 apt-get update
 apt-get install -y curl ca-certificates
 
-apt-get install -y software-properties-common gpg-agent
-add-apt-repository ppa:longsleep/golang-backports
-apt-get update
-apt-get install -y golang-go liblzo2-dev brotli libsodium-dev git make cmake gcc libc-dev
-go version
-
-git clone -b "$WALG_VERSION" --recurse-submodules https://github.com/wal-g/wal-g.git
-cd /wal-g
-go get -v -t -d ./...
-go mod vendor
-
-bash link_brotli.sh
-
-sed -i -e 's/1.0.17/1.0.18/g' link_libsodium.sh
-sed -i -e "s/download\/\$LIBSODIUM_VERSION/download\/\$LIBSODIUM_VERSION-RELEASE/g" link_libsodium.sh
-
-bash link_libsodium.sh
-
-export USE_LIBSODIUM=1
-export USE_LZO=1
-make pg_build
-
-# We want to remove all libgdal30 debs except one that is for current architecture.
-printf "shopt -s extglob\nrm /builddeps/!(*_%s.deb)" "$ARCH" | bash -s
-
 mkdir /builddeps/wal-g
 
-cp /wal-g/main/pg/wal-g /builddeps/wal-g/
+if [ "$ARCH" = "amd64" ]; then
+    PKG_NAME='wal-g-pg-ubuntu-20.04-amd64'
+else
+    PKG_NAME='wal-g-pg-ubuntu20.04-aarch64'
+fi
+
+curl -sL "https://github.com/wal-g/wal-g/releases/download/$WALG_VERSION/$PKG_NAME.tar.gz" \
+            | tar -C /builddeps/wal-g -xz
+mv "/builddeps/wal-g/$PKG_NAME" /builddeps/wal-g/wal-g

--- a/postgres-appliance/tests/docker-compose.yml
+++ b/postgres-appliance/tests/docker-compose.yml
@@ -59,8 +59,6 @@ services:
             CLONE_AWS_ENDPOINT: *aws_endpoint
             CLONE_AWS_S3_FORCE_PATH_STYLE: *aws_s3_force_path_style
             CLONE_WALE_DISABLE_S3_SSE: *wale_disable_s3_sse
-            USE_WALG: 'true'
-            WALG_BACKUP_COMPRESSION_METHOD: brotli
         hostname: spilo1
         container_name: demo-spilo1
 

--- a/postgres-appliance/tests/docker-compose.yml
+++ b/postgres-appliance/tests/docker-compose.yml
@@ -59,6 +59,8 @@ services:
             CLONE_AWS_ENDPOINT: *aws_endpoint
             CLONE_AWS_S3_FORCE_PATH_STYLE: *aws_s3_force_path_style
             CLONE_WALE_DISABLE_S3_SSE: *wale_disable_s3_sse
+            USE_WALG: 'true'
+            WALG_BACKUP_COMPRESSION_METHOD: brotli
         hostname: spilo1
         container_name: demo-spilo1
 


### PR DESCRIPTION
- decrease build time
- fix the problem of missing brotli compression type after upgrade to WAL-G v3 (ref. https://github.com/wal-g/wal-g/pull/1379)