### PR TITLE
add extra tags for uploaded Postgres log files

### DIFF
--- a/ENVIRONMENT.rst
+++ b/ENVIRONMENT.rst
@@ -90,7 +90,7 @@ Environment Configuration Settings
 - **AZURE_TENANT_ID**: (optional) Tenant ID of the Service Principal
 - **CALLBACK_SCRIPT**: the callback script to run on various cluster actions (on start, on stop, on restart, on role change). The script will receive the cluster name, connection string and the current action. See `Patroni <http://patroni.readthedocs.io/en/latest/SETTINGS.html?highlight=callback#postgresql>`__ documentation for details.
 - **LOG_S3_BUCKET**: path to the S3 bucket used for PostgreSQL daily log files (i.e. foobar, without `s3://` prefix). Spilo will add `/spilo/{LOG_BUCKET_SCOPE_PREFIX}{SCOPE}{LOG_BUCKET_SCOPE_SUFFIX}/log/` to that path. Logs are shipped if this variable is set.
-- **LOG_S3_TAGS**: map of key value pairs to be used for tagging files uploaded to S3. Values should be referencing existing environment variables.
+- **LOG_S3_TAGS**: map of key value pairs to be used for tagging files uploaded to S3. Values should be referencing existing environment variables e.g. ``{"ClusterName": "SCOPE", "Namespace": "POD_NAMESPACE"}``
 - **LOG_SHIP_SCHEDULE**: cron schedule for shipping compressed logs from ``pg_log`` (if this feature is enabled, '00 02 * * *' by default)
 - **LOG_ENV_DIR**: directory to store environment variables necessary for log shipping
 - **LOG_TMPDIR**: directory to store temporary compressed daily log files. PGROOT/../tmp by default.

--- a/ENVIRONMENT.rst
+++ b/ENVIRONMENT.rst
@@ -90,6 +90,7 @@ Environment Configuration Settings
 - **AZURE_TENANT_ID**: (optional) Tenant ID of the Service Principal
 - **CALLBACK_SCRIPT**: the callback script to run on various cluster actions (on start, on stop, on restart, on role change). The script will receive the cluster name, connection string and the current action. See `Patroni <http://patroni.readthedocs.io/en/latest/SETTINGS.html?highlight=callback#postgresql>`__ documentation for details.
 - **LOG_S3_BUCKET**: path to the S3 bucket used for PostgreSQL daily log files (i.e. foobar, without `s3://` prefix). Spilo will add `/spilo/{LOG_BUCKET_SCOPE_PREFIX}{SCOPE}{LOG_BUCKET_SCOPE_SUFFIX}/log/` to that path. Logs are shipped if this variable is set.
+- **LOG_S3_TAGS**: map of key value pairs to be used for tagging files uploaded to S3. Values should be referencing existing environment variables.
 - **LOG_SHIP_SCHEDULE**: cron schedule for shipping compressed logs from ``pg_log`` (if this feature is enabled, '00 02 * * *' by default)
 - **LOG_ENV_DIR**: directory to store environment variables necessary for log shipping
 - **LOG_TMPDIR**: directory to store temporary compressed daily log files. PGROOT/../tmp by default.

--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -19,7 +19,7 @@ FROM $BASE_IMAGE as dependencies-builder
 
 ARG DEMO
 
-ENV WALG_VERSION=v3.0.0
+ENV WALG_VERSION=v3.0.3
 
 COPY build_scripts/dependencies.sh /builddeps/
 
@@ -60,7 +60,7 @@ ENV POSTGIS_VERSION=3.4 \
     PG_MON_COMMIT=a6c5982368edd876edbee01e51b91e7387071e21 \
     SET_USER=REL4_0_1 \
     PLPROFILER=REL4_2_4 \
-    PG_PROFILE=4.5 \
+    PG_PROFILE=4.6 \
     PAM_OAUTH2=v1.0.1 \
     PG_PERMISSIONS_COMMIT=314b9359e3d77c0b2ef7dbbde97fa4be80e31925
 

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -772,7 +772,13 @@ def write_log_environment(placeholders):
     if not os.path.exists(log_env['LOG_ENV_DIR']):
         os.makedirs(log_env['LOG_ENV_DIR'])
 
-    for var in ('LOG_TMPDIR', 'LOG_AWS_REGION', 'LOG_S3_ENDPOINT', 'LOG_S3_KEY', 'LOG_S3_BUCKET', 'LOG_S3_TAGS', 'PGLOG'):
+    for var in ('LOG_TMPDIR',
+                'LOG_AWS_REGION',
+                'LOG_S3_ENDPOINT',
+                'LOG_S3_KEY',
+                'LOG_S3_BUCKET',
+                'LOG_S3_TAGS',
+                'PGLOG'):
         write_file(log_env[var], os.path.join(log_env['LOG_ENV_DIR'], var), True)
 
 

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -583,6 +583,7 @@ def get_placeholders(provider):
     placeholders.setdefault('LOG_SHIP_SCHEDULE', '1 0 * * *')
     placeholders.setdefault('LOG_S3_BUCKET', '')
     placeholders.setdefault('LOG_S3_ENDPOINT', '')
+    placeholders.setdefault('LOG_S3_TAGS', '{}')
     placeholders.setdefault('LOG_TMPDIR', os.path.abspath(os.path.join(placeholders['PGROOT'], '../tmp')))
     placeholders.setdefault('LOG_BUCKET_SCOPE_SUFFIX', '')
 
@@ -771,7 +772,7 @@ def write_log_environment(placeholders):
     if not os.path.exists(log_env['LOG_ENV_DIR']):
         os.makedirs(log_env['LOG_ENV_DIR'])
 
-    for var in ('LOG_TMPDIR', 'LOG_AWS_REGION', 'LOG_S3_ENDPOINT', 'LOG_S3_KEY', 'LOG_S3_BUCKET', 'PGLOG'):
+    for var in ('LOG_TMPDIR', 'LOG_AWS_REGION', 'LOG_S3_ENDPOINT', 'LOG_S3_KEY', 'LOG_S3_BUCKET', 'LOG_S3_TAGS', 'PGLOG'):
         write_file(log_env[var], os.path.join(log_env['LOG_ENV_DIR'], var), True)
 
 

--- a/postgres-appliance/scripts/upload_pg_log_to_s3.py
+++ b/postgres-appliance/scripts/upload_pg_log_to_s3.py
@@ -64,13 +64,13 @@ def upload_to_s3(local_file_path):
     chunk_size = 52428800  # 50 MiB
     config = TransferConfig(multipart_threshold=chunk_size, multipart_chunksize=chunk_size)
     tags = {
-        'LogEndpoint': os.getenv('LOG_S3_ENDPOINT'),
         'Namespace': os.getenv('POD_NAMESPACE'),
         'ClusterName': os.getenv('SCOPE')
     }
+    tags_str = "&".join(f"{key}={value}" for key, value in tags.items())
 
     try:
-        bucket.upload_file(local_file_path, key_name, Config=config, ExtraArgs=tags)
+        bucket.upload_file(local_file_path, key_name, Config=config, ExtraArgs={'Tagging': tags_str})
     except S3UploadFailedError as e:
         logger.exception('Failed to upload the %s to the bucket %s under the key %s. Exception: %r',
                          local_file_path, bucket_name, key_name, e)

--- a/postgres-appliance/scripts/upload_pg_log_to_s3.py
+++ b/postgres-appliance/scripts/upload_pg_log_to_s3.py
@@ -54,11 +54,7 @@ def upload_to_s3(local_file_path):
     chunk_size = 52428800  # 50 MiB
     config = TransferConfig(multipart_threshold=chunk_size, multipart_chunksize=chunk_size)
     tags = eval(os.getenv('LOG_S3_TAGS'))
-    s3_tags = {}
-    for key, value in tags.items():
-        s3_tags[key] = os.getenv(value)
-
-    s3_tags_str = "&".join(f"{key}={value}" for key, value in s3_tags.items())
+    s3_tags_str = "&".join(f"{key}={os.getenv(value)}" for key, value in tags.items())
 
     try:
         bucket.upload_file(local_file_path, key_name, Config=config, ExtraArgs={'Tagging': s3_tags_str})

--- a/postgres-appliance/scripts/upload_pg_log_to_s3.py
+++ b/postgres-appliance/scripts/upload_pg_log_to_s3.py
@@ -63,7 +63,11 @@ def upload_to_s3(local_file_path):
 
     chunk_size = 52428800  # 50 MiB
     config = TransferConfig(multipart_threshold=chunk_size, multipart_chunksize=chunk_size)
-    tags = {'LogEndpoint': os.getenv('LOG_S3_ENDPOINT'), 'Namespace': os.getenv('POD_NAMESPACE'), 'ClusterName': os.getenv('SCOPE')}
+    tags = {
+        'LogEndpoint': os.getenv('LOG_S3_ENDPOINT'),
+        'Namespace': os.getenv('POD_NAMESPACE'),
+        'ClusterName': os.getenv('SCOPE')
+    }
 
     try:
         bucket.upload_file(local_file_path, key_name, Config=config, ExtraArgs=tags)


### PR DESCRIPTION
This PR suggest to add some extra tags along with the uploaded log files so that external log analyzer tools (if they are too stupid to parse the import file path) know from which database cluster, K8s namespace and AWS account the log is coming from

The account info is only injected as environment variable by our deployment tool. Therefore, I came up with the idea to make the tags configurable. One can choose keys and values should reference existing env vars. 