### PR TITLE
enable hourly log ship mode

### DIFF
--- a/postgres-appliance/bootstrap/maybe_pg_upgrade.py
+++ b/postgres-appliance/bootstrap/maybe_pg_upgrade.py
@@ -8,7 +8,7 @@ import sys
 logger = logging.getLogger(__name__)
 
 
-def tail_postgres_log(weekday, hour):
+def tail_postgres_log(weekday):
     logdir = os.environ.get('PGLOG', '/home/postgres/pgdata/pgroot/pg_log')
     logfile = os.path.join(logdir, 'postgresql-{0}.csv'.format(weekday))
     if os.getenv('LOG_SHIP_HOURLY'):

--- a/postgres-appliance/bootstrap/maybe_pg_upgrade.py
+++ b/postgres-appliance/bootstrap/maybe_pg_upgrade.py
@@ -8,9 +8,11 @@ import sys
 logger = logging.getLogger(__name__)
 
 
-def tail_postgres_log(weekday):
+def tail_postgres_log(weekday, hour):
     logdir = os.environ.get('PGLOG', '/home/postgres/pgdata/pgroot/pg_log')
     logfile = os.path.join(logdir, 'postgresql-{0}.csv'.format(weekday))
+    if os.getenv('LOG_SHIP_HOURLY'):
+        logfile = os.path.join(logdir, 'postgresql-{0}-{1}.csv'.format(weekday, datetime.datetime.today().hour))
     return subprocess.check_output(['tail', '-n5', logfile]).decode('utf-8')
 
 

--- a/postgres-appliance/scripts/upload_pg_log_to_s3.py
+++ b/postgres-appliance/scripts/upload_pg_log_to_s3.py
@@ -16,15 +16,26 @@ from boto3.s3.transfer import TransferConfig
 logger = logging.getLogger(__name__)
 
 
-def compress_pg_log():
-    yesterday = datetime.now() - timedelta(days=1)
-    yesterday_day_number = yesterday.strftime('%u')
+def get_file_names():
+    hourly_schedule = os.getenv('LOG_SHIP_HOURLY')
+    prev_interval = datetime.now() - timedelta(days=1)
+    prev_interval_number = prev_interval.strftime('%u')
 
-    log_file = os.path.join(os.getenv('PGLOG'), 'postgresql-' + yesterday_day_number + '.csv')
-    archived_log_file = os.path.join(os.getenv('LOG_TMPDIR'), yesterday.strftime('%F') + '.csv.gz')
+    if hourly_schedule:
+        prev_interval = datetime.now() - timedelta(hours=1)
+        prev_interval_number = prev_interval.strftime('%u-%H')
+
+    log_file = os.path.join(os.getenv('PGLOG'), 'postgresql-' + prev_interval_number + '.csv')
+    archived_log_file = os.path.join(os.getenv('LOG_TMPDIR'), prev_interval.strftime('%F-%H') + '.csv.gz')
+
+    return log_file, archived_log_file
+
+
+def compress_pg_log():
+    log_file, archived_log_file = get_file_names()
 
     if os.path.getsize(log_file) == 0:
-        logger.warning("Postgres log from yesterday '%s' is empty.", log_file)
+        logger.warning("Postgres log '%s' is empty.", log_file)
         sys.exit(0)
 
     try:


### PR DESCRIPTION
The idea is to check in configure_spilo script if the provided schedule contains a / in the second position of the cron schedule. We then set an environment variable to be used in other places to decide on the log file names and Postgre's log_rotation_age.

Open questions:
- does it actually work? Especially the post_init part. Still need to test.
- is there a better way than using an extra env variable?
- more flexibility on different log rotations? For now we decided to only distinguish between daily and houry.