### PR TITLE
Fix wrong bool handling of LOG_SHIP_HOURLY

### DIFF
--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -600,7 +600,7 @@ def get_placeholders(provider):
 
     # only accept true as value or else it will be empty = disabled
     if placeholders['LOG_SHIP_HOURLY']:
-        placeholders['LOG_SHIP_HOURLY'] = os.environ.get('LOG_SHIP_HOURLY', '') in ['true', 'TRUE']
+        placeholders['LOG_SHIP_HOURLY'] = str(os.environ.get('LOG_SHIP_HOURLY', '') in ['true', 'TRUE'])
 
     # see comment for wal-e bucket prefix
     placeholders.setdefault('LOG_BUCKET_SCOPE_PREFIX', '{0}-'.format(placeholders['NAMESPACE'])

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -599,8 +599,10 @@ def get_placeholders(provider):
     placeholders.setdefault('LOG_BUCKET_SCOPE_SUFFIX', '')
 
     # only accept true as value or else it will be empty = disabled
-    if placeholders['LOG_SHIP_HOURLY']:
-        placeholders['LOG_SHIP_HOURLY'] = str(os.environ.get('LOG_SHIP_HOURLY', '') in ['true', 'TRUE'])
+    if placeholders['LOG_SHIP_HOURLY'] and os.environ.get('LOG_SHIP_HOURLY').lower() == 'true':
+        placeholders['LOG_SHIP_HOURLY'] = 'true'
+    else:
+        placeholders['LOG_SHIP_HOURLY'] = ''
 
     # see comment for wal-e bucket prefix
     placeholders.setdefault('LOG_BUCKET_SCOPE_PREFIX', '{0}-'.format(placeholders['NAMESPACE'])


### PR DESCRIPTION
Setting LOG_SHIP_HOURLY to bool leads to the following error:

```
2024-10-08 14:52:53,562 - bootstrapping - INFO - Writing to file /run/etc/log.d/env/LOG_SHIP_HOURLY
Traceback (most recent call last):
  File "/scripts/configure_spilo.py", line 1198, in <module>
    main()
  File "/scripts/configure_spilo.py", line 1160, in main
    write_log_environment(placeholders)
  File "/scripts/configure_spilo.py", line 806, in write_log_environment
    write_file(log_env[var], os.path.join(log_env['LOG_ENV_DIR'], var), True)
  File "/scripts/spilo_commons.py", line 76, in write_file
    f.write(config)
TypeError: write() argument must be str, not bool
```

Not sure, why tests do not catch this, because in my test the cluster does not even start.