### PR TITLE
fill s3 tags before copying to log env

### DIFF
--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -787,6 +787,9 @@ def write_log_environment(placeholders):
     if not os.path.exists(log_env['LOG_ENV_DIR']):
         os.makedirs(log_env['LOG_ENV_DIR'])
 
+    tags = eval(os.getenv('LOG_S3_TAGS'))
+    log_env['LOG_S3_TAGS'] = "&".join(f"{key}={os.getenv(value)}" for key, value in tags.items())
+
     for var in ('LOG_TMPDIR',
                 'LOG_SHIP_HOURLY',
                 'LOG_AWS_REGION',

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -787,7 +787,7 @@ def write_log_environment(placeholders):
     if not os.path.exists(log_env['LOG_ENV_DIR']):
         os.makedirs(log_env['LOG_ENV_DIR'])
 
-    tags = eval(os.getenv('LOG_S3_TAGS'))
+    tags = json.loads(os.getenv('LOG_S3_TAGS'))
     log_env['LOG_S3_TAGS'] = "&".join(f"{key}={os.getenv(value)}" for key, value in tags.items())
 
     for var in ('LOG_TMPDIR',

--- a/postgres-appliance/scripts/upload_pg_log_to_s3.py
+++ b/postgres-appliance/scripts/upload_pg_log_to_s3.py
@@ -3,7 +3,6 @@
 
 import boto3
 import os
-import json
 import logging
 import subprocess
 import sys
@@ -66,8 +65,7 @@ def upload_to_s3(local_file_path):
     config = TransferConfig(multipart_threshold=chunk_size, multipart_chunksize=chunk_size)
 
     try:
-        bucket.upload_file(local_file_path, key_name, Config=config,
-                           ExtraArgs={'Tagging': json.loads(os.getenv('LOG_S3_TAGS'))})
+        bucket.upload_file(local_file_path, key_name, Config=config, ExtraArgs={'Tagging': os.getenv('LOG_S3_TAGS')})
     except S3UploadFailedError as e:
         logger.exception('Failed to upload the %s to the bucket %s under the key %s. Exception: %r',
                          local_file_path, bucket_name, key_name, e)

--- a/postgres-appliance/scripts/upload_pg_log_to_s3.py
+++ b/postgres-appliance/scripts/upload_pg_log_to_s3.py
@@ -63,11 +63,10 @@ def upload_to_s3(local_file_path):
 
     chunk_size = 52428800  # 50 MiB
     config = TransferConfig(multipart_threshold=chunk_size, multipart_chunksize=chunk_size)
-    tags = eval(os.getenv('LOG_S3_TAGS'))
-    s3_tags_str = "&".join(f"{key}={os.getenv(value)}" for key, value in tags.items())
 
     try:
-        bucket.upload_file(local_file_path, key_name, Config=config, ExtraArgs={'Tagging': s3_tags_str})
+        bucket.upload_file(local_file_path, key_name, Config=config,
+                           ExtraArgs={'Tagging': eval(os.getenv('LOG_S3_TAGS'))})
     except S3UploadFailedError as e:
         logger.exception('Failed to upload the %s to the bucket %s under the key %s. Exception: %r',
                          local_file_path, bucket_name, key_name, e)

--- a/postgres-appliance/scripts/upload_pg_log_to_s3.py
+++ b/postgres-appliance/scripts/upload_pg_log_to_s3.py
@@ -3,6 +3,7 @@
 
 import boto3
 import os
+import json
 import logging
 import subprocess
 import sys
@@ -66,7 +67,7 @@ def upload_to_s3(local_file_path):
 
     try:
         bucket.upload_file(local_file_path, key_name, Config=config,
-                           ExtraArgs={'Tagging': eval(os.getenv('LOG_S3_TAGS'))})
+                           ExtraArgs={'Tagging': json.loads(os.getenv('LOG_S3_TAGS'))})
     except S3UploadFailedError as e:
         logger.exception('Failed to upload the %s to the bucket %s under the key %s. Exception: %r',
                          local_file_path, bucket_name, key_name, e)


### PR DESCRIPTION
When executing the upload command manually inside the pod the tagging works:
`envdir "/run/etc/log.d/env" /scripts/upload_pg_log_to_s3.py`

But seems that crontab only sees the variables which we [copy](https://github.com/zalando/spilo/blob/efd6eb46ee04572dfae41b91ed5629ae66b9c1f8/postgres-appliance/scripts/configure_spilo.py#L798). It will set tags with key found in LOG_S3_TAGS, but values will be `None`.

Therefore, we have to fill out the dict before copying it to the log env.
