### PR TITLE
Add new env variable PGCONNECT_ADDRESS for postgresql connect_address

### DIFF
--- a/ENVIRONMENT.rst
+++ b/ENVIRONMENT.rst
@@ -30,6 +30,7 @@ Environment Configuration Settings
 - **ALLOW_NOSSL**: set to allow clients to connect without SSL enabled.
 - **PGPORT**: port PostgreSQL listens to for client connections, 5432 by default
 - **PGVERSION**: Specifies the version of postgreSQL to reference in the bin_dir variable (/usr/lib/postgresql/PGVERSION/bin) if postgresql.bin_dir wasn't set in SPILO_CONFIGURATION
+- **PGCONNECT_ADDRESS**: When you configure postgreSQL behind NAT or you set a hostname based SSL certificate for it you might need to advertise different connect address (for example external IP, hostname instead of IP) for the replicas.
 - **SCOPE**: cluster name, multiple Spilos belonging to the same cluster must have identical scope.
 - **SSL_CA_FILE**: path to the SSL CA certificate file inside the container (by default: '')
 - **SSL_CRL_FILE**: path to the SSL Certificate Revocation List file inside the container (by default: '')

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -284,7 +284,7 @@ postgresql:
   use_unix_socket_repl: true
   name: '{{instance_data.id}}'
   listen: '*:{{PGPORT}}'
-  connect_address: {{instance_data.ip}}:{{PGPORT}}
+  connect_address: {{PGCONNECT_ADDRESS}}:{{PGPORT}}
   data_dir: {{PGDATA}}
   parameters:
     archive_command: {{{postgresql.parameters.archive_command}}}
@@ -696,6 +696,7 @@ def get_placeholders(provider):
 
     placeholders['instance_data'] = get_instance_metadata(provider)
     placeholders.setdefault('RESTAPI_CONNECT_ADDRESS', placeholders['instance_data']['ip'])
+    placeholders.setdefault('PGCONNECT_ADDRESS', placeholders['instance_data']['ip'])
 
     placeholders['BGMON_LISTEN_IP'] = get_listen_ip()
 


### PR DESCRIPTION
Spilo by default uses IP for the property ```postgresql.connect_address```. This is a problem when Patroni REST API is configured in SSL with client authentication because hostname validation is performed or behind NAT. This PR solves the problem with the introduction of environment variable: PGCONNECT_ADDRESS. You can configure it with the external IP of the spilo or dns name of spilo and the replicas will use the address PGCONNECT_ADDRESS:PGPORT when connecting the primary.