### PR TITLE
always build extensions with appropriate version of pg_config

### DIFF
--- a/postgres-appliance/build_scripts/base.sh
+++ b/postgres-appliance/build_scripts/base.sh
@@ -156,7 +156,7 @@ for version in $DEB_PG_SUPPORTED_VERSIONS; do
             pg_permissions-${PG_PERMISSIONS_COMMIT} \
             pg_profile-${PG_PROFILE} \
             "${EXTRA_EXTENSIONS[@]}"; do
-        make -C "$n" USE_PGXS=1 clean install-strip
+        make -C "$n" USE_PGXS=1 PG_CONFIG="/usr/lib/postgresql/$version/bin/pg_config" clean install-strip
     done
 done
 


### PR DESCRIPTION
There is a flaw in the building of extensions bg_mon, pg_auth_mon, set_user, pg_permissions, pg_profile, and anything in  `EXTRA_EXTENSIONS`.

The way the extensions are built is:
1. install one major version of PG
2. build dependencies
3. repeat from 1

When the `PGOLDVERSIONS` variable is populated in ascending order (e.g. `15 16`), everything is built correctly.
However, when `PGOLDVERSIONS` is populated in descending order (e.g. `16 15`),  the extensions are built (multiple times) against the highest PG version in that variable.

This is because pg_config is resolved in the build environment to reference the PostgreSQL installation with the highest major version.
So when a higher version is installed before any lower versions, the extensions are built against the higher version repeatedly.

The fix is pretty simple, and already used for building some other extensions.
We can pass PG_CONFIG variable set to appropriate `$version` (the iterator over the PostgreSQL major version) to make, and consequently the extensions are always built against all PG versions, regardless of their ordering.

building current head with "correct" order of PGOLDVERSIONS:
```
julian@fedora:~/git/spilo/postgres-appliance$ time podman build --pull --no-cache --build-arg PGVERSION=17 --build-arg PGOLDVERSIONS='15 16' . > spilo_15_16_17.out
[..]
julian@fedora:~/git/spilo/postgres-appliance$ grep pg_auth_mon.control spilo_15_16_17.out
/bin/sh /usr/lib/postgresql/15/lib/pgxs/src/makefiles/../../config/install-sh -c -m 644 .//pg_auth_mon.control '/usr/share/postgresql/15/extension/'
/bin/sh /usr/lib/postgresql/16/lib/pgxs/src/makefiles/../../config/install-sh -c -m 644 .//pg_auth_mon.control '/usr/share/postgresql/16/extension/'
/bin/sh /usr/lib/postgresql/17/lib/pgxs/src/makefiles/../../config/install-sh -c -m 644 .//pg_auth_mon.control '/usr/share/postgresql/17/extension/'
creating symlink /usr/share/postgresql/16/extension/pg_auth_mon.control -> ../../17/extension/pg_auth_mon.control
creating symlink /usr/share/postgresql/15/extension/pg_auth_mon.control -> ../../17/extension/pg_auth_mon.control
```

building current head with "bad" order of PGOLDVERSIONS

```
julian@fedora:~/git/spilo/postgres-appliance$ time podman build --pull --no-cache --build-arg PGVERSION=17 --build-arg PGOLDVERSIONS='16 15' . > spilo_16_15_17.out
[..]
julian@fedora:~/git/spilo/postgres-appliance$ grep pg_auth_mon.control spilo_16_15_17.out
/bin/sh /usr/lib/postgresql/16/lib/pgxs/src/makefiles/../../config/install-sh -c -m 644 .//pg_auth_mon.control '/usr/share/postgresql/16/extension/'
/bin/sh /usr/lib/postgresql/16/lib/pgxs/src/makefiles/../../config/install-sh -c -m 644 .//pg_auth_mon.control '/usr/share/postgresql/16/extension/'
/bin/sh /usr/lib/postgresql/17/lib/pgxs/src/makefiles/../../config/install-sh -c -m 644 .//pg_auth_mon.control '/usr/share/postgresql/17/extension/'
creating symlink /usr/share/postgresql/16/extension/pg_auth_mon.control -> ../../17/extension/pg_auth_mon.control
```

building fix with "bad" order of PGOLDVERSIONS

```
julian@fedora:~/git/spilo/postgres-appliance$ time podman build --pull --no-cache --build-arg PGVERSION=17 --build-arg PGOLDVERSIONS='16 15' . > spilo_16_15_17_fixed.out
[..]
julian@fedora:~/git/spilo/postgres-appliance$ grep pg_auth_mon.control spilo_16_15_17_fixed.out
/bin/sh /usr/lib/postgresql/16/lib/pgxs/src/makefiles/../../config/install-sh -c -m 644 .//pg_auth_mon.control '/usr/share/postgresql/16/extension/'
/bin/sh /usr/lib/postgresql/15/lib/pgxs/src/makefiles/../../config/install-sh -c -m 644 .//pg_auth_mon.control '/usr/share/postgresql/15/extension/'
/bin/sh /usr/lib/postgresql/17/lib/pgxs/src/makefiles/../../config/install-sh -c -m 644 .//pg_auth_mon.control '/usr/share/postgresql/17/extension/'
creating symlink /usr/share/postgresql/16/extension/pg_auth_mon.control -> ../../17/extension/pg_auth_mon.control
creating symlink /usr/share/postgresql/15/extension/pg_auth_mon.control -> ../../17/extension/pg_auth_mon.control
```


Best regards
Julian