### PR TITLE
Make leader tag value for native AWS configurable

### DIFF
--- a/postgres-appliance/scripts/callback_aws.py
+++ b/postgres-appliance/scripts/callback_aws.py
@@ -8,7 +8,7 @@ import sys
 import time
 
 logger = logging.getLogger(__name__)
-LEADER_LABEL_VALUE = os.environ.get('AWS_LEADER_TAG_VALUE', 'master')
+LEADER_TAG_VALUE = os.environ.get('AWS_LEADER_TAG_VALUE', 'master')
 
 def retry(func):
     def wrapped(*args, **kwargs):
@@ -71,7 +71,7 @@ def main():
 
     instance = get_instance(ec2, instance_id)
 
-    tags = {'Role': LEADER_LABEL_VALUE if role == 'primary' else role}
+    tags = {'Role': LEADER_TAG_VALUE if role == 'primary' else role}
     tag_resource(ec2, instance_id, tags)
 
     tags.update({'Instance': instance_id})

--- a/postgres-appliance/scripts/callback_aws.py
+++ b/postgres-appliance/scripts/callback_aws.py
@@ -10,6 +10,7 @@ import time
 logger = logging.getLogger(__name__)
 LEADER_TAG_VALUE = os.environ.get('AWS_LEADER_TAG_VALUE', 'master')
 
+
 def retry(func):
     def wrapped(*args, **kwargs):
         count = 0

--- a/postgres-appliance/scripts/callback_aws.py
+++ b/postgres-appliance/scripts/callback_aws.py
@@ -3,11 +3,12 @@
 import boto.ec2
 import boto.utils
 import logging
+import os
 import sys
 import time
 
 logger = logging.getLogger(__name__)
-
+LEADER_LABEL_VALUE = os.environ.get('AWS_LEADER_LABEL_VALUE', 'master')
 
 def retry(func):
     def wrapped(*args, **kwargs):
@@ -70,7 +71,7 @@ def main():
 
     instance = get_instance(ec2, instance_id)
 
-    tags = {'Role': role}
+    tags = {'Role': LEADER_LABEL_VALUE if role == 'primary' else role}
     tag_resource(ec2, instance_id, tags)
 
     tags.update({'Instance': instance_id})

--- a/postgres-appliance/scripts/callback_aws.py
+++ b/postgres-appliance/scripts/callback_aws.py
@@ -8,7 +8,7 @@ import sys
 import time
 
 logger = logging.getLogger(__name__)
-LEADER_LABEL_VALUE = os.environ.get('AWS_LEADER_LABEL_VALUE', 'master')
+LEADER_LABEL_VALUE = os.environ.get('AWS_LEADER_TAG_VALUE', 'master')
 
 def retry(func):
     def wrapped(*args, **kwargs):

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -577,7 +577,7 @@ def get_placeholders(provider):
     placeholders.setdefault('PAM_OAUTH2', '')
     placeholders.setdefault('CALLBACK_SCRIPT', '')
     placeholders.setdefault('DCS_ENABLE_KUBERNETES_API', '')
-    placeholders.setdefault('AWS_LEADER_LABEL_VALUE', 'master')
+    placeholders.setdefault('AWS_LEADER_TAG_VALUE', 'master')
     placeholders.setdefault('KUBERNETES_ROLE_LABEL', 'spilo-role')
     placeholders.setdefault('KUBERNETES_LEADER_LABEL_VALUE', 'master')
     placeholders.setdefault('KUBERNETES_STANDBY_LEADER_LABEL_VALUE', 'master')

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -577,6 +577,7 @@ def get_placeholders(provider):
     placeholders.setdefault('PAM_OAUTH2', '')
     placeholders.setdefault('CALLBACK_SCRIPT', '')
     placeholders.setdefault('DCS_ENABLE_KUBERNETES_API', '')
+    placeholders.setdefault('AWS_LEADER_LABEL_VALUE', 'master')
     placeholders.setdefault('KUBERNETES_ROLE_LABEL', 'spilo-role')
     placeholders.setdefault('KUBERNETES_LEADER_LABEL_VALUE', 'master')
     placeholders.setdefault('KUBERNETES_STANDBY_LEADER_LABEL_VALUE', 'master')


### PR DESCRIPTION
With the update to Patroni 4, the leader tag value in AWS Native will be set to "primary." This change allows users to configure their preferred value while keeping "master" as the default to maintain consistency with Kubernetes behaviour.