### PR TITLE
Update postgres_backup.sh to cleanup daily backups 

### DIFF
--- a/postgres-appliance/scripts/postgres_backup.sh
+++ b/postgres-appliance/scripts/postgres_backup.sh
@@ -40,7 +40,6 @@ else
 fi
 
 BEFORE=""
-LEFT=0
 
 NOW=$(date +%s -u)
 readonly NOW
@@ -51,14 +50,10 @@ while read -r name last_modified rest; do
             BEFORE_TIME=$last_modified
             BEFORE=$name
         fi
-    else
-        # count how many backups will remain after we remove everything up to certain date
-        ((LEFT=LEFT+1))
     fi
 done < <($WAL_E backup-list 2> /dev/null | sed '0,/^\(backup_\)\?name\s*\(last_\)\?modified\s*/d')
 
-# we want keep at least N backups even if the number of days exceeded
-if [ -n "$BEFORE" ] && [ $LEFT -ge $DAYS_TO_RETAIN ]; then
+if [ -n "$BEFORE" ]; then
     if [[ "$USE_WALG_BACKUP" == "true" ]]; then
         $WAL_E delete before FIND_FULL "$BEFORE" --confirm
     else


### PR DESCRIPTION
Removes safeguard to leave at least as many backups as BACKUP_NUM_TO_RETAIN

Currently when running backups on a schedule any less frequent then daily the backups are not cleaned up as the zalando/postgres-operator documentation suggests. See ticket #425. 

This PR fixes #425.

The safeguard was not mentioned in the [documentation](https://github.com/zalando/postgres-operator/blob/master/docs/administrator.md#wal-archiving-and-physical-basebackups).

Also: BACKUP_NUM_TO_RETAIN is a number of days i would suggest renaming it to  BACKUP_NUM_DAYS_TO_RETAIN
it is only used in the zalando/postgres-operator docs. Let me know if that fix is desired. Decided to keep the fix small for now. 

Multiple solutions already offered, this would be the most simple one. Also see possible fix in #425.

