### PR TITLE
Set proper default KUBERNETES_BOOTSTRAP_LABELS

### DIFF
--- a/ENVIRONMENT.rst
+++ b/ENVIRONMENT.rst
@@ -106,6 +106,7 @@ Environment Configuration Settings
 - **KUBERNETES_STANDBY_LEADER_LABEL_VALUE**: value of the pod label if Postgres role is standby_leader when running on Kubernetes. Default is 'master'.
 - **KUBERNETES_SCOPE_LABEL**: name of the label containing cluster name. Default is 'version'.
 - **KUBERNETES_LABELS**: a JSON describing names and values of other labels used by Patroni on Kubernetes to locate its metadata. Default is '{"application": "spilo"}'.
+- **KUBERNETES_BOOTSTRAP_LABELS**: a JSON describing names and values of labels used by Patroni as ``kubernetes.bootstrap_labels``. Default is empty.
 - **INITDB_LOCALE**: database cluster's default UTF-8 locale (en_US by default)
 - **ENABLE_WAL_PATH_COMPAT**: old Spilo images were generating wal path in the backup store using the following template ``/spilo/{WAL_BUCKET_SCOPE_PREFIX}{SCOPE}{WAL_BUCKET_SCOPE_SUFFIX}/wal/``, while new images adding one additional directory (``{PGVERSION}``) to the end. In order to avoid (unlikely) issues with restoring WALs (from S3/GC/and so on) when switching to ``spilo-13`` please set the ``ENABLE_WAL_PATH_COMPAT=true`` when deploying old cluster with ``spilo-13`` for the first time. After that the environment variable could be removed. Change of the WAL path also mean that backups stored in the old location will not be cleaned up automatically.
 - **WALE_DISABLE_S3_SSE**, **WALG_DISABLE_S3_SSE**: by default wal-e/wal-g are configured to encrypt files uploaded to S3. In order to disable it you can set this environment variable to ``true``.

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -795,7 +795,12 @@ def write_log_environment(placeholders):
     if not os.path.exists(log_env['LOG_ENV_DIR']):
         os.makedirs(log_env['LOG_ENV_DIR'])
 
-    tags = json.loads(os.getenv('LOG_S3_TAGS'))
+    try:
+        tags = json.loads(os.getenv('LOG_S3_TAGS'))
+    except (TypeError, ValueError) as e:
+        logging.warning("could not parse LOG_S3_TAGS as a JSON: %r, reverting to the default empty dict", e)
+        tags = {}
+
     log_env['LOG_S3_TAGS'] = "&".join(f"{key}={os.getenv(value)}" for key, value in tags.items())
 
     for var in ('LOG_TMPDIR',

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -585,7 +585,7 @@ def get_placeholders(provider):
     placeholders.setdefault('KUBERNETES_LABELS', KUBERNETES_DEFAULT_LABELS)
     placeholders.setdefault('KUBERNETES_USE_CONFIGMAPS', '')
     placeholders.setdefault('KUBERNETES_BYPASS_API_SERVICE', 'true')
-    placeholders.setdefault('KUBERNETES_BOOTSTRAP_LABELS', '')
+    placeholders.setdefault('KUBERNETES_BOOTSTRAP_LABELS', '{}')
     placeholders.setdefault('USE_PAUSE_AT_RECOVERY_TARGET', False)
     placeholders.setdefault('CLONE_METHOD', '')
     placeholders.setdefault('CLONE_WITH_WALE', '')


### PR DESCRIPTION
to avoid `could not parse kubernetes bootstrap_labels as a JSON: JSONDecodeError('Expecting value: line 1 column 1 (char 0)'), reverting to the default: {}` for an unset env