### PR TITLE
Fix: Expose new environment variables to Patroni run

### DIFF
--- a/postgres-appliance/runit/patroni/run
+++ b/postgres-appliance/runit/patroni/run
@@ -24,7 +24,7 @@ then
 fi
 
 # Only small subset of environment variables is allowed. We don't want accidentally disclose sensitive information
-for E in $(printenv -0 | tr '\n' ' ' | sed 's/\x00/\n/g' | grep -vE '^(KUBERNETES_(SERVICE|PORT|ROLE)[_=]|((POD_(IP|NAMESPACE))|HOSTNAME|PATH|PGHOME|LC_ALL|ENABLE_PG_MON)=)' | sed 's/=.*//g'); do
+for E in $(printenv -0 | tr '\n' ' ' | sed 's/\x00/\n/g' | grep -vE '^(KUBERNETES_(SERVICE|PORT|ROLE|LEADER_LABEL_VALUE|STANDBY_LEADER_LABEL_VALUE)[_=]|((POD_(IP|NAMESPACE))|HOSTNAME|PATH|PGHOME|LC_ALL|ENABLE_PG_MON)=)' | sed 's/=.*//g'); do
     unset $E
 done
 


### PR DESCRIPTION
# Summary

This Pull Request ensures that the newly introduced environment variables — `KUBERNETES_LEADER_LABEL_VALUE` and `KUBERNETES_STANDBY_LEADER_LABEL_VALUE` — are correctly passed to the Patroni process by removing them from the filtering logic in the entrypoint script.

# Context & Motivation

The variables  `KUBERNETES_LEADER_LABEL_VALUE` and `KUBERNETES_STANDBY_LEADER_LABEL_VALUE`  were unintentionally excluded from the environment passed to the running Patroni process due to the default filtering logic in the Spilo entrypoint script. As a result, their values were not available at runtime rendering the configuration ineffective. 

Specifically, when Patroni invokes the `callback_role.py` script, it relies on the `LEADER_LABEL_VALUE` constant, which is expected to derive its value from the `KUBERNETES_LEADER_LABEL_VALUE` environment variable. Since this variable was not passed through, the callback logic silently falls back to the default value (`master`), breaking expected behavior in customized deployments.

# Impact

- No breaking changes expected.
- Enables correct configuration of Kubernetes leader election behavior when using these new environment variables.
- Backward compatible for users not using these variables.

This aims to fix the issue https://github.com/zalando/spilo/issues/1105