### PR TITLE
Add trailing slash to AWS_EC2_METADATA_SERVICE_ENDPOINT for log env

### DIFF
--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -812,6 +812,9 @@ def write_log_environment(placeholders):
         tags = {}
 
     log_env['LOG_S3_TAGS'] = "&".join(f"{key}={os.getenv(value)}" for key, value in tags.items())
+    # support for older boto3 versions: https://github.com/boto/botocore/pull/2600
+    if not log_env['AWS_EC2_METADATA_SERVICE_ENDPOINT'].endswith('/'):
+        log_env['AWS_EC2_METADATA_SERVICE_ENDPOINT'] += '/'
 
     for var in ('LOG_TMPDIR',
                 'LOG_SHIP_HOURLY',


### PR DESCRIPTION
To support older boto3 versions