### PR TITLE
Add pgvector to extension whitelist to allow non-superuser creation

### DIFF
--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -320,7 +320,7 @@ postgresql:
     bg_mon.history_buckets: 120
     pg_stat_statements.track_utility: 'off'
     extwlist.extensions: 'btree_gin,btree_gist,citext,extra_window_functions,first_last_agg,hll,\
-hstore,hypopg,intarray,ltree,pgcrypto,pgq,pgq_node,pgvector,pg_trgm,postgres_fdw,roaringbitmap,tablefunc,uuid-ossp'
+hstore,hypopg,intarray,ltree,pgcrypto,pgq,pgq_node,pg_trgm,postgres_fdw,roaringbitmap,tablefunc,uuid-ossp,vector'
     extwlist.custom_path: /scripts
   pg_hba:
     - local   all             all                                   trust

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -320,7 +320,7 @@ postgresql:
     bg_mon.history_buckets: 120
     pg_stat_statements.track_utility: 'off'
     extwlist.extensions: 'btree_gin,btree_gist,citext,extra_window_functions,first_last_agg,hll,\
-hstore,hypopg,intarray,ltree,pgcrypto,pgq,pgq_node,pg_trgm,postgres_fdw,roaringbitmap,tablefunc,uuid-ossp'
+hstore,hypopg,intarray,ltree,pgcrypto,pgq,pgq_node,pgvector,pg_trgm,postgres_fdw,roaringbitmap,tablefunc,uuid-ossp'
     extwlist.custom_path: /scripts
   pg_hba:
     - local   all             all                                   trust


### PR DESCRIPTION
This change adds the `pgvector` extension to extension whitelist `extwlist`, enabling non-superusers to create the extension without requiring superuser privileges.