### PR TITLE
fix wal-g download url and use ubuntu 20.04

### DIFF
--- a/postgres-appliance/build_scripts/dependencies.sh
+++ b/postgres-appliance/build_scripts/dependencies.sh
@@ -29,9 +29,9 @@ apt-get install -y curl ca-certificates
 mkdir /builddeps/wal-g
 
 if [ "$ARCH" = "amd64" ]; then
-    PKG_NAME='wal-g-pg-ubuntu-22.04-amd64'
+    PKG_NAME='wal-g-pg-ubuntu-20.04-amd64'
 else
-    PKG_NAME='wal-g-pg-ubuntu-22.04-aarch64'
+    PKG_NAME='wal-g-pg-ubuntu-20.04-aarch64'
 fi
 
 curl -sL "https://github.com/wal-g/wal-g/releases/download/$WALG_VERSION/$PKG_NAME.tar.gz" \


### PR DESCRIPTION
since we downgrade wal-g version from 3.0.7 to 3.0.5 in https://github.com/zalando/spilo/pull/1133, the wal-g download url also need to be fixed  