### PR TITLE
feat: Quote admin password in bootstrap config

### DIFF
--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -260,7 +260,7 @@ bootstrap:
   {{#USE_ADMIN}}
   users:
     {{PGUSER_ADMIN}}:
-      password: {{PGPASSWORD_ADMIN}}
+      password: '{{PGPASSWORD_ADMIN}}'
       options:
         - createrole
         - createdb


### PR DESCRIPTION
The admin password in the bootstrap configuration is now enclosed in single quotes. This prevents YAML parsing errors when the password contains special characters.