### PR TITLE
Set SPILO_PROVIDER to local by default

### DIFF
--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -396,7 +396,7 @@ hstore,hypopg,intarray,ltree,pgcrypto,pgq,pgq_node,pg_trgm,postgres_fdw,roaringb
 
 
 def get_provider():
-    provider = os.environ.get('SPILO_PROVIDER')
+    provider = os.environ.get('SPILO_PROVIDER', PROVIDER_LOCAL)
     if provider:
         if provider in {PROVIDER_AWS, PROVIDER_GOOGLE, PROVIDER_OPENSTACK, PROVIDER_LOCAL}:
             return provider


### PR DESCRIPTION
Github actions does not fail token request with an excepted exception and later does not get proper rollback with 

```
requests.exceptions.InvalidHeader: Invalid return character or leading space in header: X-aws-ec2-metadata-token
```

So why not having local as default?