### PR TITLE
Properly setup clean env for ext build across major versions

### DIFF
--- a/postgres-appliance/build_scripts/base.sh
+++ b/postgres-appliance/build_scripts/base.sh
@@ -160,7 +160,8 @@ for version in $DEB_PG_SUPPORTED_VERSIONS; do
             pg_permissions-${PG_PERMISSIONS_COMMIT} \
             pg_profile-${PG_PROFILE} \
             "${EXTRA_EXTENSIONS[@]}"; do
-        make -C "$n" USE_PGXS=1 clean install-strip
+        PATH="/usr/lib/postgresql/$version/bin:$PATH" make -C "$n" USE_PGXS=1 clean
+        PATH="/usr/lib/postgresql/$version/bin:$PATH" make -C "$n" USE_PGXS=1 install-strip
     done
 done
 


### PR DESCRIPTION
to avoid things like

```
2026-02-12 12:40:20 UTC [2394]: [1-1] 698dca34.95a 0     FATAL:  could not load library "/usr/lib/postgresql/14/lib/bg_mon.so": /usr/lib/postgresql/14/lib/bg_mon.so: undefined symbol: RecoveryIsPaused
```