### PR TITLE
Update to wal-g v3.0.8

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -18,7 +18,7 @@ FROM $BASE_IMAGE as dependencies-builder
 
 ARG DEMO
 
-ENV WALG_VERSION=v3.0.5
+ENV WALG_VERSION=v3.0.8
 
 COPY build_scripts/dependencies.sh /builddeps/
 

--- a/postgres-appliance/build_scripts/dependencies.sh
+++ b/postgres-appliance/build_scripts/dependencies.sh
@@ -29,9 +29,9 @@ apt-get install -y curl ca-certificates
 mkdir /builddeps/wal-g
 
 if [ "$ARCH" = "amd64" ]; then
-    PKG_NAME='wal-g-pg-ubuntu-20.04-amd64'
+    PKG_NAME='wal-g-pg-22.04-amd64'
 else
-    PKG_NAME='wal-g-pg-ubuntu-20.04-aarch64'
+    PKG_NAME='wal-g-pg-22.04-aarch64'
 fi
 
 curl -sL "https://github.com/wal-g/wal-g/releases/download/$WALG_VERSION/$PKG_NAME.tar.gz" \


### PR DESCRIPTION
https://github.com/wal-g/wal-g/releases/tag/v3.0.8

This updates to the latest wal-g version.

It was previously pinned at v3.0.5 because of a bug in v3.0.6 (https://github.com/zalando/spilo/pull/1133) however that bug was fixed upstream.