### PR TITLE
Updating wal-g version to 3.0.8

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -18,7 +18,7 @@ FROM $BASE_IMAGE as dependencies-builder
 
 ARG DEMO
 
-ENV WALG_VERSION=v3.0.5
+ENV WALG_VERSION=v3.0.8
 
 COPY build_scripts/dependencies.sh /builddeps/
 

--- a/postgres-appliance/build_scripts/dependencies.sh
+++ b/postgres-appliance/build_scripts/dependencies.sh
@@ -29,9 +29,9 @@ apt-get install -y curl ca-certificates
 mkdir /builddeps/wal-g
 
 if [ "$ARCH" = "amd64" ]; then
-    PKG_NAME='wal-g-pg-ubuntu-20.04-amd64'
+    PKG_NAME='wal-g-pg-22.04-amd64'
 else
-    PKG_NAME='wal-g-pg-ubuntu-20.04-aarch64'
+    PKG_NAME='wal-g-pg-22.04-aarch64'
 fi
 
 curl -sL "https://github.com/wal-g/wal-g/releases/download/$WALG_VERSION/$PKG_NAME.tar.gz" \


### PR DESCRIPTION
* wal-g 3.0.8 has released containing the bug fix about s3 versioning problem
* updating to wal-g with ubuntu 22.04