### PR TITLE
Fix server version request in basebackup.sh

### DIFF
--- a/postgres-appliance/scripts/basebackup.sh
+++ b/postgres-appliance/scripts/basebackup.sh
@@ -19,6 +19,10 @@ done
 
 [[ -z $DATA_DIR || -z "$CONNSTR" || ! $RETRIES =~ ^[1-9]$ ]] && exit 1
 
+if [[ ! $CONNSTR =~ dbname= ]]; then
+    CONNSTR="${CONNSTR} dbname=postgres"
+fi
+
 if which pg_receivewal &> /dev/null; then
     PG_RECEIVEWAL=pg_receivewal
     PG_BASEBACKUP_OPTS=(-X none)
@@ -95,7 +99,9 @@ else
     receivewal_pid=$(cat "$WAL_FAST/receivewal.pid")
 fi
 
-PGVER=$(psql -d "$CONNSTR" -tAc "SELECT pg_catalog.current_setting('server_version_num')::int/10000" || echo 0)
+echo "CONNSTR: $CONNSTR"
+
+PGVER=$(psql "$CONNSTR" -tAc "SELECT pg_catalog.current_setting('server_version_num')::int/10000" || echo 0)
 if [[ $PGVER -ge 15 ]]; then
     PG_BASEBACKUP_OPTS+=("--compress=server-lz4")
 fi

--- a/postgres-appliance/scripts/basebackup.sh
+++ b/postgres-appliance/scripts/basebackup.sh
@@ -99,8 +99,6 @@ else
     receivewal_pid=$(cat "$WAL_FAST/receivewal.pid")
 fi
 
-echo "CONNSTR: $CONNSTR"
-
 PGVER=$(psql "$CONNSTR" -tAc "SELECT pg_catalog.current_setting('server_version_num')::int/10000" || echo 0)
 if [[ $PGVER -ge 15 ]]; then
     PG_BASEBACKUP_OPTS+=("--compress=server-lz4")


### PR DESCRIPTION
use `dbname=postgres` to avoid falling back to a non-existent standby db when no dbname is passed