### PR TITLE
Remove Pierone docker registry references

### DIFF
--- a/.github/workflows/kubernetes-test.yaml
+++ b/.github/workflows/kubernetes-test.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   kubernetes-installation-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,7 +3,7 @@ Configuration items specific to Spilo are listed here.
 ### Docker image
 The Docker image containing Patroni and AWS-specific code which constitutes Spilo.
 
-Example: `registry.opensource.zalan.do/acid/spilo-9.4:0.76-p1`
+Example: `ghcr.io/zalando/spilo-18:4.1-p2`
 
 ### Postgres WAL S3 bucket
 The location to store the `pg_basebackup` and the archived WAL-files of the PostgreSQL cluster.

--- a/kubernetes/spilo_kubernetes.yaml
+++ b/kubernetes/spilo_kubernetes.yaml
@@ -54,7 +54,7 @@ spec:
       serviceAccountName: operator
       containers:
       - name: *cluster_name
-        image: registry.opensource.zalan.do/acid/spilo-11:1.5-p5  # put the spilo image here
+        image: ghcr.io/zalando/spilo-18:4.1-p2  # put the spilo image here
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8008

--- a/postgres-appliance/spilok8s.yaml
+++ b/postgres-appliance/spilok8s.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: *cluster_name
-        image: registry.opensource.zalan.do/acid/spilotest-9.6:1.1-p10  # put the spilo image here
+        image: ghcr.io/zalando/spilo-18:4.1-p2  # put the spilo image here
         imagePullPolicy: Always
         ports:
         - containerPort: 8008

--- a/postgres-appliance/tests/locales_test/test_locales.sh
+++ b/postgres-appliance/tests/locales_test/test_locales.sh
@@ -6,7 +6,7 @@ source ../test_utils.sh
 
 TEST_CONTAINER_NAME='spilo-test'
 TEST_IMAGE=(
-    'registry.opensource.zalan.do/acid/spilo-cdp-14'
+    'ghcr.io/zalando/spilo-18:4.1-p2'
     'spilo'
 )
 


### PR DESCRIPTION
Removing all Pierone docker registry references as it is deprecated.