### PR TITLE
  Fix standby bootstrap when standby_primary_slot_name is set

### DIFF
--- a/postgres-appliance/scripts/basebackup.sh
+++ b/postgres-appliance/scripts/basebackup.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 RETRIES=2
+SLOT_NAME=""
+KEEP_WAL_FAST=""
 
 while getopts ":-:" optchar; do
     [[ "${optchar}" == "-" ]] || continue
@@ -13,6 +15,12 @@ while getopts ":-:" optchar; do
             ;;
         retries=* )
             RETRIES=${OPTARG#*=}
+            ;;
+        primary_slot_name=* )
+            SLOT_NAME=${OPTARG#*=}
+            ;;
+        keep_wal_fast=* )
+            KEEP_WAL_FAST=${OPTARG#*=}
             ;;
     esac
 done
@@ -59,15 +67,17 @@ function start_receivewal() {
     [ -z "$SEGMENT" ] && exit 1
 
     # run pg_receivewal until postgres will not start streaming
-    (
-        while ! pgrep -cf 'wal {0,1}receiver( process){0,1}\s+streaming' > /dev/null; do
-            # exit if pg_receivewal is not running
-            kill -0 $receivewal_pid && sleep 1 || exit
-        done
+    if [[ $KEEP_WAL_FAST != 1 ]]; then
+        (
+            while ! pgrep -cf 'wal {0,1}receiver( process){0,1}\s+streaming' > /dev/null; do
+                # exit if pg_receivewal is not running
+                kill -0 $receivewal_pid && sleep 1 || exit
+            done
 
-        kill $receivewal_pid && sleep 1
-        rm -f "${WAL_FAST:?}"/*
-    )&
+            kill $receivewal_pid && sleep 1
+            rm -f "${WAL_FAST:?}"/*
+        )&
+    fi
 
     # calculate the name of previous segment
     timeline=${SEGMENT:0:8}
@@ -86,7 +96,12 @@ function start_receivewal() {
     # therefore we will "precreate" previous file and pg_receivewal will start fetching the next one
     dd if=/dev/zero of="$WAL_FAST/$SEGMENT" bs=16k count=1k
 
-    exec $PG_RECEIVEWAL --directory="$WAL_FAST" --dbname="$CONNSTR"
+    PG_RECEIVEWAL_ARGS=(--directory="$WAL_FAST" --dbname="$CONNSTR")
+    if [[ -n "$SLOT_NAME" ]]; then
+        PG_RECEIVEWAL_ARGS+=(--slot="$SLOT_NAME")
+    fi
+
+    exec "$PG_RECEIVEWAL" "${PG_RECEIVEWAL_ARGS[@]}"
 }
 
 # make sure that there is only one receivewal running
@@ -111,6 +126,10 @@ while [[ $((ATTEMPT++)) -le $RETRIES ]]; do
     wait $basebackup_pid
     EXITCODE=$?
     if [[ $EXITCODE == 0 ]]; then
+        if [[ -n $receivewal_pid && $KEEP_WAL_FAST == 1 ]]; then
+            kill "$receivewal_pid"
+            wait "$receivewal_pid" 2>/dev/null || true
+        fi
         break
     elif [[ $ATTEMPT -le $RETRIES ]]; then
         sleep $((ATTEMPT*10))

--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -177,10 +177,13 @@ bootstrap:
       {{#STANDBY_WITH_WALG}}
       - bootstrap_standby_with_wale
       {{/STANDBY_WITH_WALG}}
-      - basebackup_fast_xlog
+      - basebackup_fast_xlog_standby
       {{#STANDBY_WITH_WALG}}
       restore_command: envdir "{{STANDBY_WALG_ENV_DIR}}" timeout "{{WAL_RESTORE_TIMEOUT}}"
         /scripts/restore_command.sh "%f" "%p"
+      {{/STANDBY_WITH_WALG}}
+      {{^STANDBY_WITH_WALG}}
+      restore_command: env WAL_FAST_ONLY=true /scripts/restore_command.sh "%f" "%p"
       {{/STANDBY_WITH_WALG}}
       {{#STANDBY_HOST}}
       host: {{STANDBY_HOST}}
@@ -384,6 +387,13 @@ hstore,hypopg,intarray,ltree,pgcrypto,pgq,pgq_node,pg_trgm,postgres_fdw,roaringb
   basebackup_fast_xlog:
     command: /scripts/basebackup.sh
     retries: 2
+  basebackup_fast_xlog_standby:
+    command: /scripts/basebackup.sh
+    retries: 2
+    keep_wal_fast: 1
+    {{#STANDBY_PRIMARY_SLOT_NAME}}
+    primary_slot_name: {{STANDBY_PRIMARY_SLOT_NAME}}
+    {{/STANDBY_PRIMARY_SLOT_NAME}}
 {{#STANDBY_WITH_WALG}}
   bootstrap_standby_with_wale:
     command: envdir "{{STANDBY_WALG_ENV_DIR}}" bash /scripts/walg_restore.sh

--- a/postgres-appliance/scripts/restore_command.sh
+++ b/postgres-appliance/scripts/restore_command.sh
@@ -32,6 +32,8 @@ readonly wal_fast_source
 
 [[ -f $wal_fast_source ]] && exec mv "${wal_fast_source}" "${wal_destination}"
 
+[[ "$WAL_FAST_ONLY" == "true" ]] && exit 1
+
 if [[ "$wal_destination" =~ /$wal_filename$ ]]; then  # Patroni fetching missing files for pg_rewind
     export WALG_DOWNLOAD_CONCURRENCY=1
 fi


### PR DESCRIPTION
 ## Summary
  - propagate `standby_primary_slot_name` to the standby bootstrap helper
  - stop `pg_receivewal` before postgres startup and preserve `wal_fast`
  - use `restore_command.sh` for local `wal_fast` replay during standby bootstrap
  - keep generic replica bootstrap free from standby slot leakage
  
  ## Problem
  When `standby_primary_slot_name` is configured, the bootstrap helper may not use the slot correctly, or the handoff from bootstrap WAL collection to postgres recovery may fail. This can lead to:
  - replication slot conflicts during startup
  - missing WAL errors after basebackup
  - broken standby bootstrap on large datasets or low-retention upstreams
  
  ## Test 
  - local script/harness validation for `basebackup.sh`
  - local script/harness validation for `restore_command.sh`
  - verified deployed standby bootstrap reaches healthy state
  - verified previous errors no longer appear:
    - `replication slot "..." is active`
    - `requested WAL segment ... has already been removed`
  