### PR TITLE
inject IRSA credentials into wal-g envdir for standby and clone clusters

### DIFF
--- a/postgres-appliance/scripts/configure_spilo.py
+++ b/postgres-appliance/scripts/configure_spilo.py
@@ -917,6 +917,12 @@ def write_walg_environment(placeholders, prefix, overwrite):
             if placeholders.get(name):
                 walg[name] = placeholders.get(name)
 
+        # fall back to bare IRSA vars if prefixed versions are not set
+        irsa_names = ['AWS_ROLE_ARN', 'AWS_WEB_IDENTITY_TOKEN_FILE', 'AWS_STS_REGIONAL_ENDPOINTS']
+        for name in irsa_names:
+            if not walg.get(name) and placeholders.get(name):
+                walg[name] = placeholders.get(name)
+
         write_envdir_names = s3_names + walg_names + aws_imds_names
     elif walg.get('WAL_GS_BUCKET') or walg.get('WALG_GS_PREFIX'):
         write_envdir_names = gs_names + walg_names


### PR DESCRIPTION
## Problem

Standby and clone clusters fail to bootstrap when IRSA is used for S3 access:

PatroniFatalException: Failed to bootstrap cluster envdir "/run/etc/wal-e.d/env-standby" bash /scripts/walg_restore.sh exited with code=1 NoCredentialProviders: no valid providers in chain

wal-g runs under `envdir` (daemontools), which replaces the process environment with only the files Spilo wrote into `/run/etc/wal-e.d/env-standby/` (or `env-clone/`). Spilo's `write_walg_environment()` only copies vars that match
the `STANDBY_` / `CLONE_` prefix into those directories. The EKS IRSA webhook injects bare `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` into the pod — without a prefix — so they are never written into the envdir, and wal-g has no credentials.

This does not affect primary clusters (wal-g there runs in the full pod environment) or kube2iam setups (Spilo unconditionally writes `AWS_INSTANCE_PROFILE=true`, and kube2iam intercepts IMDS at the node level).

## Solution

Operator:
**`pkg/cluster/k8sres.go`**: when `IRSARoleARN` is configured, explicitly inject `STANDBY_AWS_ROLE_ARN` / `STANDBY_AWS_WEB_IDENTITY_TOKEN_FILE` and `CLONE_AWS_ROLE_ARN` / `CLONE_AWS_WEB_IDENTITY_TOKEN_FILE` into the pod environment. Spilo's existing prefix-lookup loop then picks these up and writes them into the correct envdir.

Spilo:
**`postgres-appliance/scripts/configure_spilo.py`** (spilo): adds a fallback inside `write_walg_environment()` — mirroring the existing IMDS fallback pattern — that copies bare `AWS_ROLE_ARN`, `AWS_WEB_IDENTITY_TOKEN_FILE`, and `AWS_STS_REGIONAL_ENDPOINTS` into the envdir if no prefixed version was already written. This ensures older operator versions or other deployments that don't inject prefixed vars still work correctly with IRSA.

## Notes

Spilo already sets `AWS_INSTANCE_PROFILE=true` into every envdir whenever no static access key/secret is present (line 910 of `configure_spilo.py`). This fires for IRSA clusters too, but it is harmless: the AWS SDK credential chain resolves the web identity token provider first (triggered by `AWS_ROLE_ARN` + `AWS_WEB_IDENTITY_TOKEN_FILE`) and never reaches the IMDS provider that `AWS_INSTANCE_PROFILE` would activate.